### PR TITLE
Add GitHub Pages deployment and offline support

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,37 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+      - master
+      - work
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload static site
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# DnB briefing
+
+Statický briefing drum & bass novinek. Web se publikuje z adresáře `docs/` přes GitHub Pages.
+
+## Webová adresa
+
+Po zapnutí GitHub Pages pro repozitář bude briefing dostupný na:
+
+<https://dozikur.github.io/dnb-briefing/>
+
+Stránka obsahuje service worker, takže po první online návštěvě zůstane poslední načtená verze dostupná i offline ve stejném prohlížeči a na stejné adrese.
+
+## Publikace na GitHub Pages
+
+Workflow `.github/workflows/pages.yml` nasazuje obsah složky `docs/` na GitHub Pages při pushi do větví `main`, `master` nebo `work`, případně ručním spuštěním z GitHub Actions.

--- a/aggregator.py
+++ b/aggregator.py
@@ -1342,6 +1342,8 @@ if RUN_MAIN:
     html_template = """<!DOCTYPE html><html lang="cs"><meta charset="utf-8">
     <title>DnB NOVINKY</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="theme-color" content="#111827">
+    <link rel="manifest" href="manifest.webmanifest">
     <style>
     body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,'Helvetica Neue',Arial,sans-serif;max-width:900px;margin:40px auto;padding:0 16px;line-height:1.55}
     h1{font-size:28px;margin:0 0 16px}
@@ -1358,6 +1360,11 @@ if RUN_MAIN:
     <footer>
     Vygenerováno automaticky. Zdrojové kanály: Google News RSS, Reddit RSS, YouTube channel RSS, RAVE.cz feed, DnBHeard, Resident Advisor (multi-region), Hospitality, Liquicity, DnB Allstars, Rampage, Korsakov, Darkshire, Beats for Love, Hoofbeats, Roxy, EPIC, Facebook Events.
     </footer>
+    <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => navigator.serviceWorker.register('./sw.js'));
+    }
+    </script>
     </body></html>"""
     html_content = md_to_html(markdown_out, output_format="xhtml1")
     html = html_template.replace("{CONTENT}", html_content)

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html><html lang="cs"><meta charset="utf-8">
     <title>DnB NOVINKY</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
+    <meta name="theme-color" content="#111827">
+    <link rel="manifest" href="manifest.webmanifest">
     <style>
     body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,'Helvetica Neue',Arial,sans-serif;max-width:900px;margin:40px auto;padding:0 16px;line-height:1.55}
     h1{font-size:28px;margin:0 0 16px}
@@ -64,4 +66,9 @@
     <footer>
     Vygenerováno automaticky. Zdrojové kanály: Google News RSS, Reddit RSS, YouTube channel RSS, RAVE.cz feed, DnBHeard, Resident Advisor (multi-region), Hospitality, Liquicity, DnB Allstars, Rampage, Korsakov, Darkshire, Beats for Love, Hoofbeats, Roxy, EPIC, Facebook Events.
     </footer>
+    <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => navigator.serviceWorker.register('./sw.js'));
+    }
+    </script>
     </body></html>

--- a/docs/manifest.webmanifest
+++ b/docs/manifest.webmanifest
@@ -1,0 +1,11 @@
+{
+  "name": "DnB NOVINKY",
+  "short_name": "DnB NOVINKY",
+  "description": "Statický briefing drum & bass novinek s podporou offline otevření po první návštěvě.",
+  "start_url": "./",
+  "scope": "./",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#111827",
+  "lang": "cs"
+}

--- a/docs/sw.js
+++ b/docs/sw.js
@@ -1,0 +1,41 @@
+const CACHE_NAME = 'dnb-briefing-v1';
+const OFFLINE_ASSETS = [
+  './',
+  './index.html',
+  './index.md',
+  './manifest.webmanifest'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(OFFLINE_ASSETS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((cacheNames) => Promise.all(
+      cacheNames
+        .filter((cacheName) => cacheName !== CACHE_NAME)
+        .map((cacheName) => caches.delete(cacheName))
+    ))
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  event.respondWith(
+    fetch(event.request)
+      .then((response) => {
+        const responseCopy = response.clone();
+        caches.open(CACHE_NAME).then((cache) => cache.put(event.request, responseCopy));
+        return response;
+      })
+      .catch(() => caches.match(event.request).then((cached) => cached || caches.match('./index.html')))
+  );
+});


### PR DESCRIPTION
### Motivation

- Provide a simple way to publish the static briefing from `docs/` via GitHub Pages and make the site usable offline after the first visit. 

### Description

- Add a GitHub Actions workflow `.github/workflows/pages.yml` that deploys the `docs/` directory to GitHub Pages on push or manual dispatch. 
- Add an app manifest `docs/manifest.webmanifest` and a service worker `docs/sw.js` that cache the site assets for offline reopening. 
- Inject manifest link and service-worker registration into the generated `docs/index.html` and update the generator (`aggregator.py`) to include those tags when it writes `docs/index.html`. 
- Add `README.md` documenting the Pages URL and the offline behaviour. 

### Testing

- Run `python3 -m py_compile aggregator.py` to ensure the generator compiles, and it succeeded. 
- Validate `docs/manifest.webmanifest` with `python3 -m json.tool docs/manifest.webmanifest`, and it succeeded. 
- Run static assertions checking `docs/index.html` contains the manifest and service worker registration and that `docs/sw.js` contains expected symbols (`CACHE_NAME`, `fetch`), and they all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a53950f58832494155a79e433c84a)