### PR TITLE
Build automated festival intelligence briefing

### DIFF
--- a/.github/workflows/validate-briefing.yml
+++ b/.github/workflows/validate-briefing.yml
@@ -1,0 +1,32 @@
+name: Validate briefing
+
+on:
+  pull_request:
+    paths:
+      - "index.html"
+      - "news/**"
+      - "schemas/**"
+      - "scripts/**"
+      - ".github/workflows/validate-briefing.yml"
+  push:
+    branches: [main]
+    paths:
+      - "index.html"
+      - "news/**"
+      - "schemas/**"
+      - "scripts/**"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Validate manifest and reports
+        run: python scripts/validate_briefing.py --all

--- a/AUTOMATION.md
+++ b/AUTOMATION.md
@@ -1,0 +1,92 @@
+# Pondělní DnB & Festival Intelligence
+
+Tento dokument je závazná specifikace pro týdenní automatizaci. Automatizace používá veřejný web a již připojený GitHub repozitář. Bez výslovného schválení nesmí připojit novou službu, účet ani datový zdroj vyžadující přihlášení.
+
+## Harmonogram
+
+- Spuštění: každé pondělí v 06:30 `Europe/Prague`.
+- Zpracované období: předchozí kalendářní týden od pondělí do neděle.
+- Výhled: potvrzené události a strategické změny relevantní pro následujících 30 dní.
+- Cíl publikace: nejpozději v 09:00, aby byl briefing připravený na pondělní poradu po obědě.
+
+## Účel
+
+Briefing není hudební magazín. Slouží jako interní podklad pro Let It Roll a Beatworx. Každá položka musí pomáhat rozhodovat o programu, konkurenci, produkci, návštěvnickém zážitku, marketingu, ticketingu nebo strategii značky.
+
+Samostatný hudební release se zařazuje pouze tehdy, pokud mění pozici interpreta, labelu nebo festivalového trendu. Běžné releasy bez strategického dopadu se vynechávají.
+
+## Povinné sekce a pořadí
+
+1. `competition` — Přímá konkurence
+2. `festival_industry` — Festivalový průmysl
+3. `dnb_scene` — DnB scéna
+4. `cz_sk` — ČR a Slovensko
+5. `audience_sentiment` — Sentiment publika
+6. `strategic_releases` — Strategické releasy
+7. `lir_actions` — Doporučené kroky pro LIR
+
+Prázdná sekce zůstává ve výstupu jako prázdné pole `items`.
+
+## Sledovaná konkurence
+
+Prioritně sledovat Rampage, Rampage Open Air, Liquicity Festival, DnB Allstars, Hospitality, Beats for Love, Darkshire, Outlook, SUNANDBASS, Boomtown, Korsakov a další festivaly nebo promotéry s významným DnB programem. Let It Roll sledovat pouze kvůli externímu sentimentu a srovnání, nikoli jako konkurenta.
+
+Zachytit zejména:
+
+- oznámení line-upu, timetable a nové programové formáty;
+- změny venue, kapacity, termínu a délky akce;
+- cenotvorbu, ticketing, payment plans a vyprodané kategorie;
+- stage hostingy, partnerství, sponzoring a obsahové inovace;
+- návštěvnický servis, camping, dopravu, cashless a bezpečnost;
+- rušení, přesuny, počasí, produkční problémy a krizovou komunikaci;
+- recenze a opakující se sentiment publika.
+
+## Zdroje
+
+### DnB a elektronická scéna
+
+Oficiální weby a sociální kanály festivalů, promotérů, labelů a interpretů; DJ Mag; Mixmag; Resident Advisor; UKF; Drum & Bass UK; LoveThatBass; Best Drum & Bass; Drumandbass.nl; Dogs On Acid; Beatportal.
+
+### Festivalový průmysl
+
+Festival Insights; IQ Magazine; Access All Areas; Music Business Worldwide; Pollstar; Event Industry News; oficiální tiskové zprávy pořadatelů, vlastníků, ticketingových platforem a veřejných institucí.
+
+### ČR a Slovensko
+
+DNBe HearD; Hoofbeats; Musicserver; Rave.cz; GoOut; oficiální weby a kanály festivalů, klubů a promotérů.
+
+### Komunitní sentiment
+
+Reddit `r/DnB`, `r/LetItRollFestival`, `r/Rampagefestival` a relevantní veřejná diskusní vlákna. Komunitní zdroj nesmí být jediným důkazem tvrdého faktu.
+
+## Ověření
+
+- Každý tvrdý fakt musí mít primární zdroj nebo dva nezávislé sekundární zdroje.
+- Reddit a komentáře dokazují sentiment, nikoli návštěvnost, finance nebo oficiální rozhodnutí.
+- Datum publikace patří do `published_at`. Datum konání patří do `event_start` a `event_end`.
+- Neověřená tvrzení mají `confidence: unverified` a nesmějí být formulována jako fakta.
+- Nepoužívat Wikipedii jako hlavní zdroj nové zprávy.
+- Nepoužívat Google image cache, dočasné Instagram CDN adresy ani obrázky bez dohledatelného původu.
+- Pokud stabilní vizuál není dostupný, ponechat `media` prázdné.
+
+## Výstup
+
+- Čeština.
+- Celkem nejvýše 14 obsahových položek mimo sekci `lir_actions`.
+- Jedna položka obsahuje 1 až 4 krátké odstavce.
+- `why_it_matters` vysvětluje konkrétní dopad na Let It Roll.
+- `recommended_action` obsahuje jeden proveditelný krok nebo explicitní `Bez akce, pouze sledovat`.
+- Žádné umělé štítky TOP, MID nebo LOW.
+- Žádná výplň, obecné promo formulace ani duplicity z předchozího týdne bez nové informace.
+
+## Publikační postup
+
+1. Přečíst `AUTOMATION.md`, `schemas/briefing.schema.json` a aktuální `news/index.json`.
+2. Vytvořit `news/YYYY-week_N.json` ve schématu verze 2. Číslo týdne odpovídá zpracovanému období, nikoli dni spuštění.
+3. Přidat nový záznam na začátek `news/index.json`.
+4. Zkontrolovat JSON, duplicity, data, odkazy a všechna povinná pole.
+5. Vytvořit větev `automation/briefing-YYYY-week-N`.
+6. Zapsat pouze nový briefing a manifest.
+7. Otevřít nedraftový pull request s názvem `Add DnB briefing YYYY week N`.
+8. Validovaný automatizační pull request sloučí workflow `.github/workflows/validate-briefing.yml`.
+9. Pokud validace selže, nic neobcházet a vrátit přesný seznam chyb.

--- a/AUTOMATION.md
+++ b/AUTOMATION.md
@@ -88,5 +88,6 @@ Reddit `r/DnB`, `r/LetItRollFestival`, `r/Rampagefestival` a relevantní veřejn
 5. Vytvořit větev `automation/briefing-YYYY-week-N`.
 6. Zapsat pouze nový briefing a manifest.
 7. Otevřít nedraftový pull request s názvem `Add DnB briefing YYYY week N`.
-8. Validovaný automatizační pull request sloučí workflow `.github/workflows/validate-briefing.yml`.
-9. Pokud validace selže, nic neobcházet a vrátit přesný seznam chyb.
+8. Workflow `.github/workflows/validate-briefing.yml` zkontroluje celý datový archiv.
+9. Pull request zůstane připravený ke sloučení. Automatické sloučení vyžaduje samostatné schválení zápisových oprávnění.
+10. Pokud validace selže, nic neobcházet a vrátit přesný seznam chyb.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
-Get started by customizing your environment (defined in the .idx/dev.nix file) with the tools and IDE extensions you'll need for your project!
+# DnB & Festival Intelligence
 
-Learn more at https://developers.google.com/idx/guides/customize-idx-env
+Interní týdenní briefing pro Let It Roll a Beatworx publikovaný přes GitHub Pages.
+
+## Struktura
+
+- `index.html` — webový přehled a archiv.
+- `news/index.json` — dynamický seznam briefingů.
+- `news/YYYY-week_N.json` — týdenní výstupy.
+- `schemas/briefing.schema.json` — datové schéma verze 2.
+- `scripts/validate_briefing.py` — validace manifestu, historie a nových výstupů.
+- `AUTOMATION.md` — redakční a publikační pravidla.
+- `.github/workflows/validate-briefing.yml` — kontrola a automatické sloučení validních automatizačních PR.
+
+## Lokální kontrola
+
+```bash
+python scripts/validate_briefing.py --all
+```
+
+Historické soubory ve starém formátu se načítají zpětně kompatibilně. Nové briefingy musí používat schéma verze 2.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Interní týdenní briefing pro Let It Roll a Beatworx publikovaný přes GitHub
 - `schemas/briefing.schema.json` — datové schéma verze 2.
 - `scripts/validate_briefing.py` — validace manifestu, historie a nových výstupů.
 - `AUTOMATION.md` — redakční a publikační pravidla.
-- `.github/workflows/validate-briefing.yml` — kontrola a automatické sloučení validních automatizačních PR.
+- `.github/workflows/validate-briefing.yml` — kontrola manifestu a briefingů bez zápisových oprávnění.
 
 ## Lokální kontrola
 

--- a/index.html
+++ b/index.html
@@ -1,229 +1,353 @@
-﻿<!DOCTYPE html>
-<html lang="cs" class="scroll-smooth">
+<!DOCTYPE html>
+<html lang="cs">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>DnB News</title>
-  <script src="https://cdn.tailwindcss.com"></script>
+  <meta name="color-scheme" content="dark">
+  <title>DnB & Festival Intelligence</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <style>
-    html {
-        min-height: 100vh;
-        background-color: #111827;
-        background-image: linear-gradient(rgba(17, 24, 39, 0.8), rgba(17, 24, 39, 0.8)), url('https://d39-a.sdn.cz/d_39/c_img_oc_A/nPvSisOTaMB8ZnxdmD53QSS/a215/let-it-roll.jpeg');
-        background-size: cover;
-        background-position: center;
-        background-attachment: fixed;
-        background-repeat: no-repeat;
+    :root {
+      --bg: #090d14;
+      --panel: rgba(20, 27, 40, .9);
+      --panel-strong: #151d2b;
+      --line: #2b3547;
+      --text: #f5f7fb;
+      --muted: #9da8ba;
+      --accent: #ef4444;
+      --accent-soft: rgba(239, 68, 68, .14);
+      --green: #34d399;
+      --amber: #fbbf24;
+      --red: #fb7185;
+      --radius: 18px;
     }
+    * { box-sizing: border-box; }
+    html { background: var(--bg); scroll-behavior: smooth; }
     body {
-        background-color: transparent;
-        font-family: 'Montserrat', sans-serif;
+      margin: 0;
+      min-height: 100vh;
+      color: var(--text);
+      font-family: Montserrat, system-ui, sans-serif;
+      background:
+        linear-gradient(rgba(9, 13, 20, .91), rgba(9, 13, 20, .98)),
+        url("https://d39-a.sdn.cz/d_39/c_img_oc_A/nPvSisOTaMB8ZnxdmD53QSS/a215/let-it-roll.jpeg") center top / cover fixed;
     }
-    .news-list {
-      scroll-snap-type: y mandatory;
-      overflow-y: scroll;
-      height: calc(100vh - 150px); /* Make room for header and title */
-      -ms-overflow-style: none;  /* IE and Edge */
-      scrollbar-width: none;  /* Firefox */
+    a { color: inherit; }
+    .container { width: min(1180px, calc(100% - 32px)); margin: 0 auto; }
+    header {
+      position: sticky;
+      top: 0;
+      z-index: 20;
+      border-bottom: 1px solid var(--line);
+      background: rgba(9, 13, 20, .88);
+      backdrop-filter: blur(16px);
     }
-    .news-list::-webkit-scrollbar {
-      display: none; /* Chrome, Safari and Opera */
+    .header-inner {
+      min-height: 72px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 20px;
     }
-    .news-card {
-      scroll-snap-align: start;
-      min-height: 300px; /* Ensure cards have a minimum height */
-      margin-bottom: 4rem; /* Space between snap points */
+    .brand { font-size: 18px; font-weight: 800; letter-spacing: -.03em; }
+    .brand span { border-bottom: 3px solid var(--accent); padding-bottom: 4px; }
+    select {
+      max-width: 240px;
+      padding: 10px 38px 10px 12px;
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      color: var(--text);
+      background: var(--panel-strong);
+      font: inherit;
     }
-    .news-card:last-child {
-      margin-bottom: 0;
+    .hero { padding: 58px 0 28px; }
+    .eyebrow { color: var(--accent); font-size: 13px; font-weight: 800; letter-spacing: .16em; text-transform: uppercase; }
+    h1 { max-width: 900px; margin: 12px 0 14px; font-size: clamp(34px, 6vw, 64px); line-height: 1.02; letter-spacing: -.055em; }
+    .period { color: var(--muted); font-size: 15px; }
+    .summary {
+      margin: 26px 0 8px;
+      padding: 26px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: linear-gradient(135deg, rgba(239, 68, 68, .13), var(--panel));
+      box-shadow: 0 24px 60px rgba(0, 0, 0, .25);
+    }
+    .summary h2 { margin: 0 0 14px; font-size: 18px; }
+    .summary ul { display: grid; gap: 10px; margin: 0; padding-left: 20px; }
+    .summary li { color: #dce2eb; line-height: 1.55; }
+    .tabs { display: flex; gap: 8px; overflow-x: auto; padding: 16px 0 4px; scrollbar-width: none; }
+    .tabs::-webkit-scrollbar { display: none; }
+    .tab {
+      flex: 0 0 auto;
+      padding: 9px 12px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      color: var(--muted);
+      background: rgba(20, 27, 40, .72);
+      font: inherit;
+      font-size: 12px;
+      font-weight: 700;
+      cursor: pointer;
+    }
+    .tab.active, .tab:hover { color: white; border-color: var(--accent); background: var(--accent-soft); }
+    main { padding-bottom: 80px; }
+    .section { margin-top: 42px; scroll-margin-top: 100px; }
+    .section-head { display: flex; align-items: baseline; justify-content: space-between; gap: 16px; margin-bottom: 15px; }
+    .section h2 { margin: 0; font-size: clamp(22px, 3vw, 30px); letter-spacing: -.035em; }
+    .count { color: var(--muted); font-size: 12px; }
+    .grid { display: grid; gap: 18px; }
+    .card {
+      overflow: hidden;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--panel);
+      box-shadow: 0 18px 44px rgba(0, 0, 0, .22);
+    }
+    .card-layout { display: grid; grid-template-columns: minmax(0, 1fr); }
+    .cover { width: 100%; height: 260px; object-fit: cover; background: #111827; }
+    .body { padding: 24px; }
+    .meta { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-bottom: 13px; }
+    .badge { padding: 6px 9px; border-radius: 999px; background: var(--accent-soft); color: #fecaca; font-size: 11px; font-weight: 800; }
+    .badge.confirmed { color: var(--green); background: rgba(52, 211, 153, .12); }
+    .badge.probable { color: var(--amber); background: rgba(251, 191, 36, .12); }
+    .badge.unverified { color: var(--red); background: rgba(251, 113, 133, .12); }
+    .date { color: var(--muted); font-size: 12px; }
+    .card h3 { margin: 0 0 14px; font-size: clamp(20px, 3vw, 27px); line-height: 1.24; letter-spacing: -.03em; }
+    .paragraphs { display: grid; gap: 11px; color: #ccd3de; line-height: 1.65; font-size: 14px; }
+    .paragraphs p { margin: 0; }
+    .insight-grid { display: grid; gap: 10px; margin-top: 18px; }
+    .insight { padding: 14px 16px; border-radius: 12px; background: rgba(9, 13, 20, .68); border-left: 3px solid var(--accent); }
+    .insight.action { border-left-color: var(--green); }
+    .insight strong { display: block; margin-bottom: 5px; color: white; font-size: 11px; letter-spacing: .08em; text-transform: uppercase; }
+    .insight span { color: #cbd5e1; font-size: 13px; line-height: 1.5; }
+    .sources { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 18px; }
+    .source { padding: 7px 9px; border: 1px solid var(--line); border-radius: 8px; color: var(--muted); text-decoration: none; font-size: 11px; }
+    .source:hover { color: white; border-color: #64748b; }
+    .media { margin-top: 18px; }
+    .media iframe { width: 100%; border: 0; border-radius: 12px; background: white; }
+    .media img { width: 100%; max-height: 520px; object-fit: cover; border-radius: 12px; }
+    .empty { padding: 18px; border: 1px dashed var(--line); border-radius: 12px; color: var(--muted); }
+    .error { margin: 50px 0; padding: 20px; border: 1px solid #7f1d1d; border-radius: 14px; background: rgba(127, 29, 29, .22); color: #fecaca; }
+    footer { padding: 28px 0 46px; border-top: 1px solid var(--line); color: var(--muted); font-size: 12px; }
+    @media (min-width: 820px) {
+      .card-layout.with-cover { grid-template-columns: 36% minmax(0, 1fr); }
+      .cover { height: 100%; min-height: 360px; }
+      .body { padding: 30px; }
+      .insight-grid { grid-template-columns: 1fr 1fr; }
     }
   </style>
 </head>
-
-<body class="antialiased">
-  <header class="bg-gray-900/80 backdrop-blur-md sticky top-0 z-50 border-b border-gray-700">
-    <nav class="container mx-auto px-6 py-4 flex justify-between items-center">
-      <div class="text-2xl tracking-tighter text-white">
-        <span class="font-bold border-b-4 border-red-500 pb-1">DnB</span><span class="font-semibold"> News</span>
-      </div>
-      <div class="flex items-center space-x-4">
-        <div>
-          <label for="period-select" class="text-sm font-medium text-gray-400 mr-2">Období
-          <select id="period-select" class="bg-gray-800 border border-gray-600 rounded-md py-1 px-2 text-white focus:ring-blue-500 focus:border-blue-500">
-            <!-- Options will be populated by JS -->
-          </select>
-        </div>
-      </div>
-    </nav>
+<body>
+  <header>
+    <div class="container header-inner">
+      <div class="brand"><span>DnB</span> & Festival Intelligence</div>
+      <select id="period-select" aria-label="Vybrat týden"></select>
+    </div>
   </header>
 
-  <main class="container mx-auto px-4">
-    <section id="overview">
-      <div class="text-center my-8 relative">
-        <h1 class="text-4xl md:text-5xl font-extrabold tracking-tight text-white">DnB News</h1>
-        <p id="date-range" class="mt-2 text-lg text-red-500"></p>
-      </div>
-      <div class="news-list" id="news-container">
-        <!-- News cards will be loaded here -->
-      </div>
+  <div class="container">
+    <section class="hero">
+      <div class="eyebrow">Interní briefing pro Let It Roll</div>
+      <h1 id="headline">Načítám briefing</h1>
+      <div id="period" class="period"></div>
+      <div id="summary"></div>
+      <nav id="tabs" class="tabs" aria-label="Sekce briefingu"></nav>
     </section>
-  </main>
+    <main id="content"></main>
+    <footer>DnB & Festival Intelligence · interní pracovní přehled</footer>
+  </div>
 
   <script>
-    // This list is now dynamically injected
-    const newsFiles = ["news/2026-week_1.json","news/2026-week_2.json","news/2026-week_3.json","news/2026-week_4.json","news/2026-week_5.json","news/2026-week_6.json","news/2026-week_7.json","news/2026-week_8.json","news/2026-week_9.json","news/2026-week_10.json","news/2026-week_11.json","news/2026-week_12.json","news/2026-week_13.json","news/2026-week_14.json","news/2026-week_15.json","news/2026-week_16.json","news/2026-week_17.json","news/2026-week_18.json","news/2026-week_19.json","news/2026-week_20.json","news/2026-week_21.json","news/2026-week_22.json","news/2026-week_23.json","news/2026-week_24.json","news/2026-week_25.json","news/2026-week_26.json","news/2026-week_27.json"];
-  </script>
+    const state = { manifest: [], currentFile: null };
+    const sectionNames = {
+      competition: "Přímá konkurence",
+      festival_industry: "Festivalový průmysl",
+      dnb_scene: "DnB scéna",
+      cz_sk: "ČR a Slovensko",
+      audience_sentiment: "Sentiment publika",
+      strategic_releases: "Strategické releasy",
+      lir_actions: "Doporučené kroky pro LIR",
+      legacy_events: "Festivaly a eventy",
+      legacy_music: "DnB scéna a hudba",
+      legacy_sentiment: "Sentiment a diskuse",
+      legacy_other: "Další vývoj scény"
+    };
 
-  <script>
-    document.addEventListener('DOMContentLoaded', () => {
-      const periodSelect = document.getElementById('period-select');
-      const newsContainer = document.getElementById('news-container');
-      const dateRangeEl = document.getElementById('date-range');
+    const esc = (value = "") => String(value).replace(/[&<>'"]/g, char => ({
+      "&": "&amp;", "<": "&lt;", ">": "&gt;", "'": "&#39;", '"': "&quot;"
+    })[char]);
 
-      const renderCard = (item) => {
-        const sourceLink = item.source_url ?
-          `<a href="${item.source_url}" target="_blank" class="hover:underline">${item.source}</a>` :
-          item.source;
+    const safeUrl = value => {
+      try {
+        const url = new URL(value);
+        return url.protocol === "https:" ? url.href : "";
+      } catch { return ""; }
+    };
 
-        const contentHtml = Array.isArray(item.content)
-          ? item.content.map(p => {
-              if (p.startsWith('soundcloud:')) {
-                const soundcloudValue = p.slice('soundcloud:'.length).trim();
-                const soundcloudTarget = soundcloudValue.startsWith('http')
-                  ? encodeURIComponent(soundcloudValue)
-                  : `https%3A//api.soundcloud.com/tracks/${soundcloudValue}`;
-                const embedUrl = `https://w.soundcloud.com/player/?url=${soundcloudTarget}`;
-                return `<div class="my-4"><iframe width="100%" height="166" scrolling="no" frameborder="no" allow="autoplay" src="${embedUrl}&color=%23ff5500&auto_play=false&hide_related=false&show_comments=true&show_user=true&show_reposts=false&show_teaser=true"></iframe></div>`;
-              } else if (p.startsWith('spotify-track:')) {
-                const trackId = p.split(':')[1];
-                const embedUrl = `https://open.spotify.com/embed/track/${trackId}`;
-                return `<div class="my-4"><iframe style="border-radius:12px" src="${embedUrl}?utm_source=generator" width="100%" height="152" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>`;
-              } else if (p.startsWith('spotify-album:')) {
-                const albumId = p.split(':')[1];
-                const embedUrl = `https://open.spotify.com/embed/album/${albumId}`;
-                return `<div class="my-4"><iframe style="border-radius:12px" src="${embedUrl}?utm_source=generator" width="100%" height="352" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe></div>`;
-              } else if (p.startsWith('youtube:')) {
-                const videoId = p.split(':')[1].trim();
-                const embedUrl = `https://www.youtube.com/embed/${videoId}`;
-                return `<div class="my-4 aspect-video"><iframe src="${embedUrl}" title="YouTube video" class="w-full h-full rounded-lg" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen loading="lazy"></iframe></div>`;
-              } else {
-                if (p.startsWith('instagram-post:')) {
-                  const postId = p.split(':')[1].trim();
-                  const instagramUrl = `https://www.instagram.com/p/${postId}/`;
-                  const instagramEmbedUrl = `https://www.instagram.com/p/${postId}/embed`;
-                  return `
-                    <div class="my-5 rounded-xl border border-slate-700 bg-slate-900/60 p-3">
-                      <iframe
-                        src="${instagramEmbedUrl}"
-                        width="100%"
-                        height="620"
-                        frameborder="0"
-                        scrolling="no"
-                        allowtransparency="true"
-                        class="w-full rounded-lg bg-white">
-                      </iframe>
-                      <p class="mt-3 text-sm text-slate-400 text-center">
-                        Pokud se Instagram nenačte, <a href="${instagramUrl}" target="_blank" rel="noopener noreferrer" class="text-pink-400 hover:underline">otevřít post na Instagramu</a>.
-                      </p>
-                    </div>
-                  `;
-                }                return `<p class="text-gray-300 mb-4 leading-relaxed">${p}</p>`;
-              }
-            }).join('')
-          : `<p class="text-gray-300 mb-4 leading-relaxed">${item.content}</p>`;
+    const formatDate = value => {
+      if (!value) return "";
+      const date = new Date(`${value}T12:00:00Z`);
+      return Number.isNaN(date.getTime()) ? "" : date.toLocaleDateString("cs-CZ", { day: "numeric", month: "long", year: "numeric" });
+    };
 
-        return `
-          <div class="news-card group bg-gray-800/60 backdrop-blur-sm rounded-xl overflow-hidden shadow-2xl flex flex-col md:flex-row items-start mx-auto max-w-5xl">
-            <div class="md:w-2/5 w-full p-6 md:p-8">
-              <img src="${item.image}" alt="${item.title}" class="w-full h-full object-cover rounded-xl shadow-lg transition-transform duration-500 group-hover:scale-105" loading="lazy">
-            </div>
-            <div class="md:w-3/5 w-full p-6 pt-0 md:p-8 md:pl-0 flex flex-col justify-between self-stretch">
-              <div>
-                <div class="flex justify-between items-start mb-3">
-                    <span class="inline-block px-3 py-1 bg-gradient-to-r from-red-600 to-red-500 text-white text-sm font-bold rounded-full">
-                      ${item.genre}
-                    </span>
-                    <p class="text-sm text-slate-400 whitespace-nowrap ml-4">
-                      ${new Date(item.date).toLocaleDateString('cz-CZ', { year: 'numeric', month: 'long', day: 'numeric' })}
-                    </p>
-                </div>
-                <h4 class="font-bold text-2xl md:text-3xl mb-4 text-white group-hover:text-red-400 transition-colors">${item.title}</h4>
-                <div class="news-content text-base pr-4">${contentHtml}</div>
-              </div>
-              <div class="mt-6 text-right">
-                <p class="text-sm text-slate-500">Zdroj: ${sourceLink}</p>
-              </div>
+    const parseLegacyMedia = content => {
+      const media = [];
+      for (const part of Array.isArray(content) ? content : []) {
+        if (typeof part !== "string") continue;
+        if (part.startsWith("instagram-post:")) media.push({ type: "instagram", url: `https://www.instagram.com/p/${part.slice(15).trim()}/` });
+        if (part.startsWith("youtube:")) media.push({ type: "youtube", url: `https://www.youtube.com/watch?v=${part.slice(8).trim()}` });
+        if (part.startsWith("spotify-track:")) media.push({ type: "spotify", url: `https://open.spotify.com/track/${part.slice(14).trim()}` });
+        if (part.startsWith("spotify-album:")) media.push({ type: "spotify", url: `https://open.spotify.com/album/${part.slice(14).trim().split("?")[0]}` });
+        if (part.startsWith("soundcloud:")) {
+          const value = part.slice(11).trim();
+          media.push({ type: "soundcloud", url: value.startsWith("http") ? value : `https://api.soundcloud.com/tracks/${value}` });
+        }
+      }
+      return media;
+    };
+
+    const legacySection = item => {
+      const value = `${item.genre || ""} ${item.title || ""}`.toLowerCase();
+      if (/reddit|social|sentiment|diskus/.test(value)) return "legacy_sentiment";
+      if (/festival|event|tour|lineup|recap|klub|party|párty|venue|arena/.test(value)) return "legacy_events";
+      if (/release|album|single|track|set|mix|interview|rozhovor|artist|label|music|hudb/.test(value)) return "legacy_music";
+      return "legacy_other";
+    };
+
+    const normalizeLegacy = (items, file) => {
+      const groups = new Map();
+      for (const item of items) {
+        const id = legacySection(item);
+        if (!groups.has(id)) groups.set(id, []);
+        const rawContent = Array.isArray(item.content) ? item.content : [item.content];
+        groups.get(id).push({
+          id: `legacy-${item.id || groups.get(id).length + 1}`,
+          published_at: item.date,
+          event_start: null,
+          event_end: null,
+          title: item.title,
+          summary: rawContent.filter(part => typeof part === "string" && !/^(instagram-post|youtube|spotify-track|spotify-album|soundcloud):/.test(part)),
+          why_it_matters: "",
+          recommended_action: "",
+          region: "",
+          confidence: "",
+          sources: item.source_url ? [{ name: item.source || "Zdroj", url: item.source_url, kind: "secondary" }] : [],
+          media: parseLegacyMedia(rawContent),
+          legacy_image: item.image,
+          legacy_genre: item.genre
+        });
+      }
+      const match = file.match(/(\d{4})-week_(\d+)/);
+      return {
+        headline: "Archivní týdenní přehled",
+        period: { year: Number(match?.[1]), week: Number(match?.[2]) },
+        executive_summary: [],
+        sections: [...groups].map(([id, sectionItems]) => ({ id, title: sectionNames[id], items: sectionItems }))
+      };
+    };
+
+    const renderMedia = media => {
+      const url = safeUrl(media.url);
+      if (!url) return "";
+      if (media.type === "image") return `<div class="media"><img src="${esc(url)}" alt="" loading="lazy"></div>`;
+      if (media.type === "instagram") {
+        const match = url.match(/instagram\.com\/(?:p|reel)\/([^/?]+)/);
+        return match ? `<div class="media"><iframe height="620" loading="lazy" src="https://www.instagram.com/p/${esc(match[1])}/embed"></iframe></div>` : "";
+      }
+      if (media.type === "youtube") {
+        const id = new URL(url).searchParams.get("v") || url.split("/").pop();
+        return `<div class="media"><iframe height="420" loading="lazy" allowfullscreen src="https://www.youtube.com/embed/${esc(id)}"></iframe></div>`;
+      }
+      if (media.type === "spotify") {
+        const match = url.match(/spotify\.com\/(track|album)\/([^/?]+)/);
+        return match ? `<div class="media"><iframe height="${match[1] === "album" ? 352 : 152}" loading="lazy" src="https://open.spotify.com/embed/${esc(match[1])}/${esc(match[2])}"></iframe></div>` : "";
+      }
+      if (media.type === "soundcloud") return `<div class="media"><iframe height="166" loading="lazy" src="https://w.soundcloud.com/player/?url=${encodeURIComponent(url)}"></iframe></div>`;
+      return "";
+    };
+
+    const renderCard = item => {
+      const stableImage = safeUrl(item.legacy_image || "");
+      const cover = stableImage ? `<img class="cover" src="${esc(stableImage)}" alt="" loading="lazy">` : "";
+      const dates = [item.published_at ? `Publikováno ${formatDate(item.published_at)}` : "", item.event_start ? `Event ${formatDate(item.event_start)}` : ""].filter(Boolean).join(" · ");
+      const confidence = item.confidence ? `<span class="badge ${esc(item.confidence)}">${esc(item.confidence)}</span>` : "";
+      const genre = item.legacy_genre ? `<span class="badge">${esc(item.legacy_genre)}</span>` : "";
+      const sources = (item.sources || []).map(source => {
+        const url = safeUrl(source.url);
+        return url ? `<a class="source" href="${esc(url)}" target="_blank" rel="noopener noreferrer">${esc(source.name)} · ${esc(source.kind)}</a>` : "";
+      }).join("");
+      const media = (item.media || []).map(renderMedia).join("");
+      return `
+        <article class="card">
+          <div class="card-layout ${cover ? "with-cover" : ""}">
+            ${cover}
+            <div class="body">
+              <div class="meta">${confidence}${genre}<span class="date">${esc(dates)}</span></div>
+              <h3>${esc(item.title)}</h3>
+              <div class="paragraphs">${(item.summary || []).map(paragraph => `<p>${esc(paragraph)}</p>`).join("")}</div>
+              ${(item.why_it_matters || item.recommended_action) ? `
+                <div class="insight-grid">
+                  ${item.why_it_matters ? `<div class="insight"><strong>Dopad pro LIR</strong><span>${esc(item.why_it_matters)}</span></div>` : ""}
+                  ${item.recommended_action ? `<div class="insight action"><strong>Další krok</strong><span>${esc(item.recommended_action)}</span></div>` : ""}
+                </div>` : ""}
+              ${sources ? `<div class="sources">${sources}</div>` : ""}
+              ${media}
             </div>
           </div>
-        `;
-      };
+        </article>`;
+    };
 
-      const loadNews = async (period) => {
-        newsContainer.innerHTML = '';
-        try {
-          const response = await fetch(`${period}`, { cache: 'no-cache' });
-          if (!response.ok) throw new Error(`Network response was not ok: ${response.statusText}`);
-          const newsItems = await response.json();
-          if (newsItems.length > 0) {
-            newsItems.forEach(item => {
-              newsContainer.innerHTML += renderCard(item);
-            });
-          } else {
-            newsContainer.innerHTML = '<p class="text-center text-gray-400">Pro vybrané období nebyly nalezeny žádné zprávy.</p>';
-          }
-          const [year, week] = period.replace('news/','').replace('.json','').split('-');
-          dateRangeEl.textContent = `Týden ${week.replace('week_', '')}, ${year}`;
-        } catch (error) { 
-          console.error('Error loading news:', error);
-          newsContainer.innerHTML = `<p class="text-center text-red-500">Nastala chyba pĹ™i naÄŤĂ­tĂˇnĂ­ zprĂˇv pro ${period}.</p>`;
-        }
-      };
+    const render = (raw, file) => {
+      const report = Array.isArray(raw) ? normalizeLegacy(raw, file) : raw;
+      document.getElementById("headline").textContent = report.headline || "DnB & Festival Intelligence";
+      const period = report.period || {};
+      const range = period.window_start && period.window_end ? `${formatDate(period.window_start)} až ${formatDate(period.window_end)}` : `Týden ${period.week || ""}, ${period.year || ""}`;
+      document.getElementById("period").textContent = range;
+      const summary = report.executive_summary || [];
+      document.getElementById("summary").innerHTML = summary.length ? `<div class="summary"><h2>Klíčové závěry</h2><ul>${summary.map(item => `<li>${esc(item)}</li>`).join("")}</ul></div>` : "";
+      const sections = report.sections || [];
+      document.getElementById("tabs").innerHTML = sections.map((section, index) => `<button class="tab ${index === 0 ? "active" : ""}" data-target="section-${esc(section.id)}">${esc(section.title || sectionNames[section.id] || section.id)}</button>`).join("");
+      document.getElementById("content").innerHTML = sections.map(section => `
+        <section class="section" id="section-${esc(section.id)}">
+          <div class="section-head"><h2>${esc(section.title || sectionNames[section.id] || section.id)}</h2><span class="count">${section.items.length} položek</span></div>
+          ${section.items.length ? `<div class="grid">${section.items.map(renderCard).join("")}</div>` : `<div class="empty">Žádná relevantní novinka v tomto období.</div>`}
+        </section>`).join("");
+      document.querySelectorAll(".tab").forEach(button => button.addEventListener("click", () => {
+        document.querySelectorAll(".tab").forEach(tab => tab.classList.remove("active"));
+        button.classList.add("active");
+        document.getElementById(button.dataset.target)?.scrollIntoView({ behavior: "smooth" });
+      }));
+    };
 
-      const populatePeriodSelector = () => {
-        try {
-          const periods = newsFiles.slice();
-          periods.sort((a, b) => Number(b.match(/week_(\d+)/)[1]) - Number(a.match(/week_(\d+)/)[1]));
+    const loadBriefing = async file => {
+      state.currentFile = file;
+      const response = await fetch(file, { cache: "no-store" });
+      if (!response.ok) throw new Error(`Briefing se nepodařilo načíst: ${response.status}`);
+      render(await response.json(), file);
+    };
 
-          if (periods.length === 0) {
-              periodSelect.innerHTML = '<option>Žádná data k zobrazení­</option>';
-              return;
-          }
+    const init = async () => {
+      try {
+        const response = await fetch("news/index.json", { cache: "no-store" });
+        if (!response.ok) throw new Error(`Manifest se nepodařilo načíst: ${response.status}`);
+        const manifest = await response.json();
+        state.manifest = manifest.briefings || [];
+        const select = document.getElementById("period-select");
+        select.innerHTML = state.manifest.map(entry => `<option value="${esc(entry.file)}">Týden ${entry.week}, ${entry.year}</option>`).join("");
+        select.addEventListener("change", () => loadBriefing(select.value).catch(showError));
+        if (!state.manifest.length) throw new Error("Manifest neobsahuje žádné briefingy.");
+        await loadBriefing(state.manifest[0].file);
+      } catch (error) { showError(error); }
+    };
 
-          periods.forEach(periodFile => {
-            const period = periodFile.replace('news/','').replace('.json','');
-            const [year, week] = period.split('-');
-            const option = document.createElement('option');
-            option.value = periodFile;
-            option.textContent = `Týden ${week.replace('week_', '')}, ${year}`;
-            periodSelect.appendChild(option);
-          });
+    const showError = error => {
+      document.getElementById("headline").textContent = "Briefing není dostupný";
+      document.getElementById("content").innerHTML = `<div class="error">${esc(error.message || error)}</div>`;
+    };
 
-          periodSelect.addEventListener('change', () => {
-            loadNews(periodSelect.value);
-          });
-
-          if (periods.length > 0) {
-            loadNews(periods[0]);
-          }
-        } catch (error) {
-          console.error('Error populating period selector:', error);
-          periodSelect.innerHTML = '<option>Chyba naÄŤĂ­tĂˇnĂ­</option>';
-        }
-      };
-
-      populatePeriodSelector();
-    });
+    init();
   </script>
 </body>
 </html>
-
-
-
-
-
-
-
-

--- a/news/index.json
+++ b/news/index.json
@@ -1,0 +1,32 @@
+{
+  "schema_version": 1,
+  "briefings": [
+    { "year": 2026, "week": 27, "file": "news/2026-week_27.json" },
+    { "year": 2026, "week": 26, "file": "news/2026-week_26.json" },
+    { "year": 2026, "week": 25, "file": "news/2026-week_25.json" },
+    { "year": 2026, "week": 24, "file": "news/2026-week_24.json" },
+    { "year": 2026, "week": 23, "file": "news/2026-week_23.json" },
+    { "year": 2026, "week": 22, "file": "news/2026-week_22.json" },
+    { "year": 2026, "week": 21, "file": "news/2026-week_21.json" },
+    { "year": 2026, "week": 20, "file": "news/2026-week_20.json" },
+    { "year": 2026, "week": 19, "file": "news/2026-week_19.json" },
+    { "year": 2026, "week": 18, "file": "news/2026-week_18.json" },
+    { "year": 2026, "week": 17, "file": "news/2026-week_17.json" },
+    { "year": 2026, "week": 16, "file": "news/2026-week_16.json" },
+    { "year": 2026, "week": 15, "file": "news/2026-week_15.json" },
+    { "year": 2026, "week": 14, "file": "news/2026-week_14.json" },
+    { "year": 2026, "week": 13, "file": "news/2026-week_13.json" },
+    { "year": 2026, "week": 12, "file": "news/2026-week_12.json" },
+    { "year": 2026, "week": 11, "file": "news/2026-week_11.json" },
+    { "year": 2026, "week": 10, "file": "news/2026-week_10.json" },
+    { "year": 2026, "week": 9, "file": "news/2026-week_9.json" },
+    { "year": 2026, "week": 8, "file": "news/2026-week_8.json" },
+    { "year": 2026, "week": 7, "file": "news/2026-week_7.json" },
+    { "year": 2026, "week": 6, "file": "news/2026-week_6.json" },
+    { "year": 2026, "week": 5, "file": "news/2026-week_5.json" },
+    { "year": 2026, "week": 4, "file": "news/2026-week_4.json" },
+    { "year": 2026, "week": 3, "file": "news/2026-week_3.json" },
+    { "year": 2026, "week": 2, "file": "news/2026-week_2.json" },
+    { "year": 2026, "week": 1, "file": "news/2026-week_1.json" }
+  ]
+}

--- a/schemas/briefing.schema.json
+++ b/schemas/briefing.schema.json
@@ -1,0 +1,95 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dozikur.github.io/dnb-briefing/schemas/briefing.schema.json",
+  "title": "DnB & Festival Intelligence Briefing",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "period", "headline", "executive_summary", "sections", "sources_scanned"],
+  "properties": {
+    "schema_version": { "const": 2 },
+    "period": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["year", "week", "window_start", "window_end", "generated_at"],
+      "properties": {
+        "year": { "type": "integer", "minimum": 2026 },
+        "week": { "type": "integer", "minimum": 1, "maximum": 53 },
+        "window_start": { "type": "string", "format": "date" },
+        "window_end": { "type": "string", "format": "date" },
+        "generated_at": { "type": "string", "format": "date-time" }
+      }
+    },
+    "headline": { "type": "string", "minLength": 8, "maxLength": 160 },
+    "executive_summary": {
+      "type": "array",
+      "minItems": 1,
+      "maxItems": 5,
+      "items": { "type": "string", "minLength": 20, "maxLength": 360 }
+    },
+    "sections": {
+      "type": "array",
+      "minItems": 7,
+      "maxItems": 7,
+      "items": { "$ref": "#/$defs/section" }
+    },
+    "sources_scanned": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 2, "maxLength": 120 },
+      "uniqueItems": true
+    }
+  },
+  "$defs": {
+    "section": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "title", "items"],
+      "properties": {
+        "id": { "enum": ["competition", "festival_industry", "dnb_scene", "cz_sk", "audience_sentiment", "strategic_releases", "lir_actions"] },
+        "title": { "type": "string", "minLength": 2, "maxLength": 80 },
+        "items": { "type": "array", "maxItems": 6, "items": { "$ref": "#/$defs/item" } }
+      }
+    },
+    "item": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "published_at", "event_start", "event_end", "title", "summary", "why_it_matters", "recommended_action", "region", "category", "competitors", "confidence", "sources", "media", "tags"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]{7,100}$" },
+        "published_at": { "type": "string", "format": "date" },
+        "event_start": { "type": ["string", "null"], "format": "date" },
+        "event_end": { "type": ["string", "null"], "format": "date" },
+        "title": { "type": "string", "minLength": 8, "maxLength": 180 },
+        "summary": { "type": "array", "minItems": 1, "maxItems": 4, "items": { "type": "string", "minLength": 20, "maxLength": 520 } },
+        "why_it_matters": { "type": "string", "minLength": 20, "maxLength": 520 },
+        "recommended_action": { "type": "string", "minLength": 10, "maxLength": 300 },
+        "region": { "enum": ["world", "europe", "cz_sk", "global"] },
+        "category": { "enum": ["competition", "festival_industry", "dnb_scene", "cz_sk", "audience_sentiment", "strategic_release", "lir_action"] },
+        "competitors": { "type": "array", "items": { "type": "string", "minLength": 2, "maxLength": 80 }, "uniqueItems": true },
+        "confidence": { "enum": ["confirmed", "probable", "unverified"] },
+        "sources": { "type": "array", "minItems": 1, "maxItems": 5, "items": { "$ref": "#/$defs/source" } },
+        "media": { "type": "array", "maxItems": 3, "items": { "$ref": "#/$defs/media" } },
+        "tags": { "type": "array", "maxItems": 8, "items": { "type": "string", "minLength": 2, "maxLength": 40 }, "uniqueItems": true }
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "url", "kind"],
+      "properties": {
+        "name": { "type": "string", "minLength": 2, "maxLength": 100 },
+        "url": { "type": "string", "format": "uri", "pattern": "^https://" },
+        "kind": { "enum": ["primary", "secondary", "community"] }
+      }
+    },
+    "media": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["type", "url"],
+      "properties": {
+        "type": { "enum": ["image", "instagram", "youtube", "spotify", "soundcloud"] },
+        "url": { "type": "string", "format": "uri", "pattern": "^https://" }
+      }
+    }
+  }
+}

--- a/scripts/validate_briefing.py
+++ b/scripts/validate_briefing.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Validate the manifest, legacy archive, and all schema v2 briefings."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from datetime import date, datetime
+from pathlib import Path
+from urllib.parse import urlparse
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "news" / "index.json"
+SECTION_IDS = [
+    "competition", "festival_industry", "dnb_scene", "cz_sk",
+    "audience_sentiment", "strategic_releases", "lir_actions",
+]
+CATEGORIES = {
+    "competition", "festival_industry", "dnb_scene", "cz_sk",
+    "audience_sentiment", "strategic_release", "lir_action",
+}
+REGIONS = {"world", "europe", "cz_sk", "global"}
+CONFIDENCE = {"confirmed", "probable", "unverified"}
+SOURCE_KINDS = {"primary", "secondary", "community"}
+MEDIA_TYPES = {"image", "instagram", "youtube", "spotify", "soundcloud"}
+
+
+class ValidationError(Exception):
+    pass
+
+
+def fail(message: str) -> None:
+    raise ValidationError(message)
+
+
+def load_json(path: Path):
+    try:
+        return json.loads(path.read_text(encoding="utf-8-sig"))
+    except FileNotFoundError:
+        fail(f"Missing file: {path.relative_to(ROOT)}")
+    except json.JSONDecodeError as exc:
+        fail(f"Invalid JSON in {path.relative_to(ROOT)}: {exc}")
+
+
+def text(value, field: str, minimum: int, maximum: int) -> str:
+    if not isinstance(value, str) or not minimum <= len(value.strip()) <= maximum:
+        fail(f"{field} must contain {minimum} to {maximum} characters")
+    return value.strip()
+
+
+def iso_date(value, field: str) -> date:
+    try:
+        return date.fromisoformat(value)
+    except (TypeError, ValueError):
+        fail(f"{field} must use YYYY-MM-DD")
+
+
+def https_url(value, field: str) -> None:
+    if not isinstance(value, str):
+        fail(f"{field} must be a URL")
+    parsed = urlparse(value)
+    if parsed.scheme != "https" or not parsed.netloc:
+        fail(f"{field} must be a valid HTTPS URL")
+
+
+def exact_keys(value, keys: set[str], field: str) -> None:
+    if not isinstance(value, dict) or set(value) != keys:
+        fail(f"{field} keys must be exactly {sorted(keys)}")
+
+
+def validate_source(value: dict, field: str) -> None:
+    exact_keys(value, {"name", "url", "kind"}, field)
+    text(value["name"], f"{field}.name", 2, 100)
+    https_url(value["url"], f"{field}.url")
+    if value["kind"] not in SOURCE_KINDS:
+        fail(f"{field}.kind is invalid")
+
+
+def validate_media(value: dict, field: str) -> None:
+    exact_keys(value, {"type", "url"}, field)
+    if value["type"] not in MEDIA_TYPES:
+        fail(f"{field}.type is invalid")
+    https_url(value["url"], f"{field}.url")
+
+
+def validate_unique_text_list(value, field: str, maximum: int, max_text: int = 80) -> None:
+    if not isinstance(value, list) or len(value) > maximum:
+        fail(f"{field} must contain at most {maximum} values")
+    cleaned = [text(item, field, 2, max_text) for item in value]
+    if len(cleaned) != len(set(cleaned)):
+        fail(f"{field} contains duplicates")
+
+
+def validate_v2(path: Path, report: dict) -> list[str]:
+    try:
+        top_keys = {"schema_version", "period", "headline", "executive_summary", "sections", "sources_scanned"}
+        exact_keys(report, top_keys, "report")
+        if report["schema_version"] != 2:
+            fail("schema_version must be 2")
+
+        period = report["period"]
+        exact_keys(period, {"year", "week", "window_start", "window_end", "generated_at"}, "period")
+        if not isinstance(period["year"], int) or period["year"] < 2026:
+            fail("period.year is invalid")
+        if not isinstance(period["week"], int) or not 1 <= period["week"] <= 53:
+            fail("period.week is invalid")
+        start = iso_date(period["window_start"], "period.window_start")
+        end = iso_date(period["window_end"], "period.window_end")
+        if start > end:
+            fail("period.window_start is after period.window_end")
+        try:
+            datetime.fromisoformat(period["generated_at"].replace("Z", "+00:00"))
+        except (TypeError, ValueError):
+            fail("period.generated_at must be an ISO datetime")
+        expected_filename = f"{period['year']}-week_{period['week']}.json"
+        if path.name != expected_filename:
+            fail(f"filename must be {expected_filename}")
+
+        text(report["headline"], "headline", 8, 160)
+        bullets = report["executive_summary"]
+        if not isinstance(bullets, list) or not 1 <= len(bullets) <= 5:
+            fail("executive_summary must contain 1 to 5 bullets")
+        for index, bullet in enumerate(bullets):
+            text(bullet, f"executive_summary[{index}]", 20, 360)
+
+        sections = report["sections"]
+        if not isinstance(sections, list) or len(sections) != 7:
+            fail("sections must contain all seven sections")
+        actual_section_ids = [section.get("id") for section in sections if isinstance(section, dict)]
+        if actual_section_ids != SECTION_IDS:
+            fail(f"section order must be {SECTION_IDS}")
+
+        seen_ids: set[str] = set()
+        seen_titles: set[str] = set()
+        non_action_count = 0
+        for section_index, section in enumerate(sections):
+            section_field = f"sections[{section_index}]"
+            exact_keys(section, {"id", "title", "items"}, section_field)
+            text(section["title"], f"{section_field}.title", 2, 80)
+            items = section["items"]
+            if not isinstance(items, list) or len(items) > 6:
+                fail(f"{section_field}.items must contain at most 6 items")
+            if section["id"] != "lir_actions":
+                non_action_count += len(items)
+
+            for item_index, item in enumerate(items):
+                field = f"{section_field}.items[{item_index}]"
+                item_keys = {
+                    "id", "published_at", "event_start", "event_end", "title", "summary",
+                    "why_it_matters", "recommended_action", "region", "category", "competitors",
+                    "confidence", "sources", "media", "tags",
+                }
+                exact_keys(item, item_keys, field)
+                item_id = text(item["id"], f"{field}.id", 8, 100)
+                if not re.fullmatch(r"[a-z0-9][a-z0-9-]+", item_id):
+                    fail(f"{field}.id must be a lowercase slug")
+                if item_id in seen_ids:
+                    fail(f"duplicate item id: {item_id}")
+                seen_ids.add(item_id)
+
+                published = iso_date(item["published_at"], f"{field}.published_at")
+                if not start <= published <= end:
+                    fail(f"{field}.published_at is outside the reporting window")
+                event_start = iso_date(item["event_start"], f"{field}.event_start") if item["event_start"] else None
+                event_end = iso_date(item["event_end"], f"{field}.event_end") if item["event_end"] else None
+                if event_end and not event_start:
+                    fail(f"{field}.event_end requires event_start")
+                if event_start and event_end and event_end < event_start:
+                    fail(f"{field}.event_end is before event_start")
+
+                title = text(item["title"], f"{field}.title", 8, 180)
+                normalized = re.sub(r"\W+", " ", title.casefold()).strip()
+                if normalized in seen_titles:
+                    fail(f"duplicate title: {title}")
+                seen_titles.add(normalized)
+
+                paragraphs = item["summary"]
+                if not isinstance(paragraphs, list) or not 1 <= len(paragraphs) <= 4:
+                    fail(f"{field}.summary must contain 1 to 4 paragraphs")
+                for paragraph_index, paragraph in enumerate(paragraphs):
+                    text(paragraph, f"{field}.summary[{paragraph_index}]", 20, 520)
+                text(item["why_it_matters"], f"{field}.why_it_matters", 20, 520)
+                text(item["recommended_action"], f"{field}.recommended_action", 10, 300)
+                if item["region"] not in REGIONS:
+                    fail(f"{field}.region is invalid")
+                if item["category"] not in CATEGORIES:
+                    fail(f"{field}.category is invalid")
+                if item["confidence"] not in CONFIDENCE:
+                    fail(f"{field}.confidence is invalid")
+                validate_unique_text_list(item["competitors"], f"{field}.competitors", 10)
+                validate_unique_text_list(item["tags"], f"{field}.tags", 8, 40)
+
+                sources = item["sources"]
+                if not isinstance(sources, list) or not 1 <= len(sources) <= 5:
+                    fail(f"{field}.sources must contain 1 to 5 sources")
+                for source_index, source in enumerate(sources):
+                    validate_source(source, f"{field}.sources[{source_index}]")
+                if item["confidence"] == "confirmed":
+                    has_primary = any(source["kind"] == "primary" for source in sources)
+                    hosts = {urlparse(source["url"]).netloc for source in sources}
+                    if not has_primary and len(hosts) < 2:
+                        fail(f"{field}: confirmed claims need a primary source or two independent sources")
+
+                media = item["media"]
+                if not isinstance(media, list) or len(media) > 3:
+                    fail(f"{field}.media must contain at most 3 entries")
+                for media_index, media_item in enumerate(media):
+                    validate_media(media_item, f"{field}.media[{media_index}]")
+
+        if non_action_count > 14:
+            fail("the report may contain at most 14 non-action items")
+        validate_unique_text_list(report["sources_scanned"], "sources_scanned", 100, 120)
+        if not report["sources_scanned"]:
+            fail("sources_scanned must not be empty")
+        return []
+    except ValidationError as exc:
+        return [f"{path.relative_to(ROOT)}: {exc}"]
+
+
+def validate_legacy(path: Path, report: list) -> list[str]:
+    warnings: list[str] = []
+    for index, item in enumerate(report):
+        if not isinstance(item, dict):
+            warnings.append(f"{path.relative_to(ROOT)}[{index}] is not an object")
+            continue
+        for required in ("title", "content", "source", "genre", "image"):
+            if required not in item:
+                warnings.append(f"{path.relative_to(ROOT)}[{index}] missing {required}")
+    return warnings
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--all", action="store_true")
+    parser.add_argument("files", nargs="*")
+    args = parser.parse_args()
+
+    try:
+        manifest = load_json(MANIFEST)
+        exact_keys(manifest, {"schema_version", "briefings"}, "manifest")
+        if manifest["schema_version"] != 1 or not isinstance(manifest["briefings"], list):
+            fail("manifest has an unsupported structure")
+    except ValidationError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    errors: list[str] = []
+    warnings: list[str] = []
+    seen_files: set[str] = set()
+    seen_periods: set[tuple[int, int]] = set()
+    for entry in manifest["briefings"]:
+        try:
+            exact_keys(entry, {"year", "week", "file"}, "manifest entry")
+            expected = f"news/{entry['year']}-week_{entry['week']}.json"
+            if entry["file"] != expected:
+                fail(f"manifest expected {expected}, got {entry['file']}")
+            period = (entry["year"], entry["week"])
+            if entry["file"] in seen_files or period in seen_periods:
+                fail(f"duplicate manifest entry: {period}")
+            seen_files.add(entry["file"])
+            seen_periods.add(period)
+        except ValidationError as exc:
+            errors.append(str(exc))
+
+    targets = [ROOT / entry["file"] for entry in manifest["briefings"]] if args.all or not args.files else [ROOT / item for item in args.files]
+    for path in targets:
+        try:
+            report = load_json(path)
+        except ValidationError as exc:
+            errors.append(str(exc))
+            continue
+        if isinstance(report, list):
+            warnings.extend(validate_legacy(path, report))
+        elif isinstance(report, dict) and report.get("schema_version") == 2:
+            errors.extend(validate_v2(path, report))
+        else:
+            errors.append(f"{path.relative_to(ROOT)} has an unsupported structure")
+
+    for warning in warnings:
+        print(f"WARNING: {warning}")
+    for error in errors:
+        print(f"ERROR: {error}", file=sys.stderr)
+    print(f"Validated {len(targets)} report(s): {len(errors)} error(s), {len(warnings)} legacy warning(s)")
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Co se mění

- nový webový přehled zaměřený na konkurenci festivalů, festivalový průmysl a dopady pro Let It Roll
- dynamický manifest týdnů místo ručního seznamu v `index.html`
- zpětná kompatibilita se všemi historickými JSON výstupy
- datové schéma verze 2 s odděleným datem publikace a konání
- povinné zdroje, míra jistoty, dopad pro LIR a konkrétní další krok
- redakční specifikace pro pondělní automatizaci
- read-only GitHub Actions validace manifestu a briefingů

## Proč

Původní web byl statický feed bez prioritizace a bez aktivního generátoru. Týdenní soubory měly nekonzistentní kategorie, chybějící data, duplicitní ID a nerozlišovaly datum zprávy od data eventu.

## Dopad

Historický archiv zůstává dostupný. Nové briefingy používají řízenou strukturu: Přímá konkurence, Festivalový průmysl, DnB scéna, ČR a Slovensko, Sentiment publika, Strategické releasy a Doporučené kroky pro LIR.

## Ověření

- lokální test schema v2: prošel
- lokální test historického formátu: prošel
- kontrola syntaxe JavaScriptu: prošla
- vzdálené soubory byly porovnány s lokálně ověřenými verzemi
- workflow v PR ověří celý manifest a historický archiv

Automatické slučování není součástí PR. Workflow má pouze `contents: read`.