### PR TITLE
Refine festival competition intelligence brief

### DIFF
--- a/.github/workflows/validate-briefing.yml
+++ b/.github/workflows/validate-briefing.yml
@@ -3,6 +3,7 @@ name: Validate briefing
 on:
   pull_request:
     paths:
+      - "AUTOMATION.md"
       - "index.html"
       - "news/**"
       - "schemas/**"
@@ -11,6 +12,7 @@ on:
   push:
     branches: [main]
     paths:
+      - "AUTOMATION.md"
       - "index.html"
       - "news/**"
       - "schemas/**"

--- a/AUTOMATION.md
+++ b/AUTOMATION.md
@@ -15,6 +15,14 @@ Briefing není hudební magazín. Slouží jako interní podklad pro Let It Roll
 
 Samostatný hudební release se zařazuje pouze tehdy, pokud mění pozici interpreta, labelu nebo festivalového trendu. Běžné releasy bez strategického dopadu se vynechávají.
 
+## Poučení z historických briefingů
+
+Největší hodnotu pro poradu měly zprávy, které ukázaly změnu konkurenčního formátu nebo konkrétní provozní a obchodní riziko. Patřily sem například reakce návštěvníků na prostor a produkci Rampage, nový imerzivní formát Section 63, lineupová strategie Liquicity, přesun WORSHIP do severoamerických arén, FestProtect od StubHubu, rušení akcí kvůli vedru, kolaps festivalové stage a problémy s odpadem v kempech.
+
+Nízkou hodnotu měly rutinní releasy, běžné rozhovory k albům, jednotlivé klubové pozvánky, nostalgické výroční zprávy a kuriozity bez dopadu na festivalové rozhodování. Tyto položky se nesmějí používat jako výplň.
+
+Před každým během přečíst nejméně čtyři poslední briefingy. Novou položku zařadit jen tehdy, pokud obsahuje skutečný posun oproti již publikované informaci. Opakované téma musí výslovně popsat, co se změnilo.
+
 ## Povinné sekce a pořadí
 
 1. `competition` — Přímá konkurence
@@ -29,17 +37,74 @@ Prázdná sekce zůstává ve výstupu jako prázdné pole `items`.
 
 ## Sledovaná konkurence
 
-Prioritně sledovat Rampage, Rampage Open Air, Liquicity Festival, DnB Allstars, Hospitality, Beats for Love, Darkshire, Outlook, SUNANDBASS, Boomtown, Korsakov a další festivaly nebo promotéry s významným DnB programem. Let It Roll sledovat pouze kvůli externímu sentimentu a srovnání, nikoli jako konkurenta.
+### Přímí konkurenti
+
+Prioritně sledovat Rampage, Rampage Open Air, Liquicity Festival, DnB Allstars, Hospitality, Beats for Love, Darkshire, Outlook, SUNANDBASS, Boomtown a Korsakov. Doplňovat další festivaly nebo promotéry, pokud soutěží o stejné DnB publikum, stejné umělce, podobný termín, podobnou destinaci nebo podobný rozpočet návštěvníka.
+
+### Strategické benchmarky
+
+WORSHIP a velké DnB arénové projekty; významné multižánrové festivaly s hlavním DnB programem; sportovní a kulturní akce, které umisťují DnB na hlavní stage; nové destination festivaly a festivalové formáty využitelné jako benchmark pro Let It Roll.
+
+Let It Roll sledovat pouze kvůli externímu sentimentu, reputaci a srovnání. Nevydávat vlastní oznámení jako konkurenční novinku.
 
 Zachytit zejména:
 
-- oznámení line-upu, timetable a nové programové formáty;
-- změny venue, kapacity, termínu a délky akce;
-- cenotvorbu, ticketing, payment plans a vyprodané kategorie;
-- stage hostingy, partnerství, sponzoring a obsahové inovace;
-- návštěvnický servis, camping, dopravu, cashless a bezpečnost;
-- rušení, přesuny, počasí, produkční problémy a krizovou komunikaci;
-- recenze a opakující se sentiment publika.
+- nové termíny, překryvy s LIR, změny délky akce a vstup na nové trhy;
+- venue, kapacitu, počet stages, hlavní produkční prvky a změny areálu;
+- nové programové koncepty, exkluzivní sety, stage hostingy a práci s headlinery;
+- lineup pouze tehdy, pokud ukazuje strategii, překryv s LIR, změnu žánrového směru nebo konkurenční tlak na booking;
+- cenu vstupenek, cenové vlny, payment plans, VIP, camping a vyprodané kategorie;
+- návštěvnický servis, dopravu, cashless, vodu, toalety, camping, crowd flow a bezpečnost;
+- marketingovou kampaň, positioning, partnerství, sponzoring, livestream a práci s obsahem;
+- reakce publika na zvuk, stage design, kapacitu, lineup, ceny a zázemí;
+- rušení, přesuny, počasí, produkční problémy, refundace a krizovou komunikaci.
+
+Každá položka v `competition` musí odpovědět:
+
+1. Co se tento týden změnilo.
+2. Kterého konkurenta se změna týká.
+3. Jaký konkrétní důkaz nebo měřitelný údaj ji podporuje.
+4. Jaký trend nebo konkurenční tah změna představuje.
+5. Jaký je dopad na Let It Roll.
+6. Jaký jeden krok má LIR udělat nebo co má dále sledovat.
+
+## Festivalový průmysl
+
+Sekce `festival_industry` neslouží pro obecné hudební novinky. Hledat pouze změny, které ovlivňují ekonomiku, provoz, riziko nebo budoucí podobu festivalů.
+
+Povinné tematické okruhy:
+
+- ekonomika festivalů, náklady, marže, prodeje, pozdní nákup vstupenek a spotřebitelská důvěra;
+- ticketing, refundace, pojištění, dynamické ceny, sekundární trh a nové prodejní platformy;
+- vlastnictví, akvizice, konsolidace a kroky Live Nation, Superstruct, AEG, CTS Eventim, Ticketmaster a See Tickets;
+- rušení festivalů, insolvence, uzavírání venue a problémy dodavatelského řetězce;
+- extrémní počasí, klimatická odolnost, bezpečnost, regulace a povolovací procesy;
+- stage technologie, zvuk, crowd management, cashless, festivalové aplikace a provozní inovace;
+- camping, doprava, voda, odpady, udržitelnost a návštěvnický komfort;
+- nové příjmy, partnerství, sponzoring a rozšiřování festivalu mimo samotný hudební program.
+
+Zprávu zařadit pouze tehdy, pokud lze vysvětlit konkrétní dopad na rozpočet, produkci, marketing, ticketing, bezpečnost nebo návštěvnický zážitek LIR.
+
+## Výběrový filtr
+
+Každého kandidáta interně posoudit podle čtyř kritérií. Hodnocení se na webu nezobrazuje.
+
+- dopad na Let It Roll: 0 až 3 body;
+- novost oproti posledním čtyřem briefingům: 0 až 2 body;
+- síla důkazů: 0 až 2 body;
+- rozsah nebo význam změny: 0 až 2 body.
+
+Zařadit položky se součtem nejméně 5 bodů. Výjimkou je bezprostřední bezpečnostní, reputační nebo termínové riziko pro LIR.
+
+Nezařazovat:
+
+- běžný release bez festivalového nebo bookingového dopadu;
+- rozhovor, který pouze propaguje nové album;
+- rutinní klubovou pozvánku nebo lokální seznam akcí;
+- samotný lineup bez analýzy strategie a konkurenčního dopadu;
+- recyklované oznámení bez nové informace;
+- jeden izolovaný komentář vydávaný za sentiment celé komunity;
+- kuriozitu bez použitelného závěru pro festival.
 
 ## Zdroje
 
@@ -59,6 +124,8 @@ DNBe HearD; Hoofbeats; Musicserver; Rave.cz; GoOut; oficiální weby a kanály f
 
 Reddit `r/DnB`, `r/LetItRollFestival`, `r/Rampagefestival` a relevantní veřejná diskusní vlákna. Komunitní zdroj nesmí být jediným důkazem tvrdého faktu.
 
+Sentiment shrnout pouze při opakujícím se vzorci ve více komentářích nebo zdrojích. Uvést, co lidé chválí, co kritizují, zda jsou názory rozdělené a jaká provozní nebo obchodní lekce z toho plyne. Jednotlivý virální komentář nestačí.
+
 ## Ověření
 
 - Každý tvrdý fakt musí mít primární zdroj nebo dva nezávislé sekundární zdroje.
@@ -73,15 +140,25 @@ Reddit `r/DnB`, `r/LetItRollFestival`, `r/Rampagefestival` a relevantní veřejn
 
 - Čeština.
 - Celkem nejvýše 14 obsahových položek mimo sekci `lir_actions`.
-- Jedna položka obsahuje 1 až 4 krátké odstavce.
+- Položky se řadí podle významu, ale nepoužívají štítky TOP, MID ani LOW.
+- Titulek formuluje analytický závěr, nikoli pouze název článku.
+- `summary` obsahuje 2 až 4 krátké věty: změna, důkaz, měřítko a nutný kontext.
 - `why_it_matters` vysvětluje konkrétní dopad na Let It Roll.
 - `recommended_action` obsahuje jeden proveditelný krok nebo explicitní `Bez akce, pouze sledovat`.
-- Žádné umělé štítky TOP, MID nebo LOW.
+- `executive_summary` obsahuje 3 až 5 bodů vhodných k přednesení na poradě bez čtení celého webu.
+- `competition` obsahuje zpravidla 2 až 5 položek.
+- `festival_industry` obsahuje zpravidla 1 až 4 položky.
+- `dnb_scene` obsahuje nejvýše 3 strategické položky.
+- `cz_sk` obsahuje 1 až 3 položky, pokud existují skutečně relevantní změny.
+- `audience_sentiment` obsahuje nejvýše 3 doložené vzorce.
+- `strategic_releases` obsahuje 0 až 2 položky.
+- `lir_actions` shrnuje 3 až 5 konkrétních úkolů z celého briefingu.
+- Minimální počty se nevynucují. Prázdná sekce je lepší než výplň.
 - Žádná výplň, obecné promo formulace ani duplicity z předchozího týdne bez nové informace.
 
 ## Publikační postup
 
-1. Přečíst `AUTOMATION.md`, `schemas/briefing.schema.json` a aktuální `news/index.json`.
+1. Přečíst `AUTOMATION.md`, `schemas/briefing.schema.json`, aktuální `news/index.json` a nejméně čtyři poslední briefingy.
 2. Vytvořit `news/YYYY-week_N.json` ve schématu verze 2. Číslo týdne odpovídá zpracovanému období, nikoli dni spuštění.
 3. Přidat nový záznam na začátek `news/index.json`.
 4. Zkontrolovat JSON, duplicity, data, odkazy a všechna povinná pole.


### PR DESCRIPTION
## Co se zpřesňuje

- přesná definice přímé konkurence a strategických benchmarků
- povinné otázky pro každou konkurenční zprávu
- samostatné tematické okruhy festivalového průmyslu
- interní výběrové skóre podle dopadu, novosti, důkazů a rozsahu
- explicitní seznam obsahového šumu, který se nemá publikovat
- práce s posledními čtyřmi briefingy kvůli duplicitám a změnám
- přesná podoba shrnutí pro pondělní poradu

## Východisko

Historické týdny ukázaly nejvyšší hodnotu u zpráv o Rampage, Liquicity, DnB Allstars, Beats for Love, Section 63, WORSHIP, FestProtect, extrémním počasí, krizové komunikaci, produkci a campingu. Rutinní releasy, promo rozhovory a klubové pozvánky vytvářely šum.

## Ověření

Změna upravuje pouze redakční specifikaci a rozšiřuje trigger existující read-only validace na `AUTOMATION.md`. Pondělní automatizace byla aktualizována stejnými pravidly.