### PR TITLE
Require DnB scene and r/DnB coverage

### DIFF
--- a/AUTOMATION.md
+++ b/AUTOMATION.md
@@ -11,9 +11,11 @@ Tento dokument je závazná specifikace pro týdenní automatizaci. Automatizace
 
 ## Účel
 
-Briefing není hudební magazín. Slouží jako interní podklad pro Let It Roll a Beatworx. Každá položka musí pomáhat rozhodovat o programu, konkurenci, produkci, návštěvnickém zážitku, marketingu, ticketingu nebo strategii značky.
+Briefing je vyvážený přehled tří rovnocenných oblastí: drum and bass scény, přímé festivalové konkurence a širšího festivalového průmyslu. Slouží jako interní podklad pro Let It Roll, Beatworx a LIR Recordings.
 
-Samostatný hudební release se zařazuje pouze tehdy, pokud mění pozici interpreta, labelu nebo festivalového trendu. Běžné releasy bez strategického dopadu se vynechávají.
+Scénová zpráva nemusí mít okamžitý provozní dopad na LIR. Musí ale pomáhat chápat, kteří interpreti a labely rostou, jak se mění zvuk a publikum, jaké nové projekty nebo formáty vznikají a co se v komunitě skutečně řeší. U položek z `dnb_scene`, `audience_sentiment` a `strategic_releases` se dopad posuzuje také z pohledu bookingu, dramaturgie, labelu, obsahu a dlouhodobého vývoje scény.
+
+Běžný samostatný release se nezařazuje automaticky. Výběr má zachytit nejdůležitější alba, EP, spolupráce, návraty, labelové přesuny a kampaně, které ukazují posun interpreta, labelu nebo subžánru. Festivalová témata nesmějí vytlačit povinné pokrytí DnB scény a Redditu.
 
 ## Poučení z historických briefingů
 
@@ -33,7 +35,7 @@ Před každým během přečíst nejméně čtyři poslední briefingy. Novou po
 6. `strategic_releases` — Strategické releasy
 7. `lir_actions` — Doporučené kroky pro LIR
 
-Prázdná sekce zůstává ve výstupu jako prázdné pole `items`.
+Sekce `competition`, `cz_sk` a `strategic_releases` mohou zůstat prázdné, pokud nejsou doložené relevantní změny. Od týdne 29 roku 2026 nesmějí být prázdné sekce `dnb_scene` a `audience_sentiment`. Nedostupnost povinného zdroje je chyba sběru a důvod běh zastavit, nikoli důvod publikovat degradovaný briefing.
 
 ## Sledovaná konkurence
 
@@ -85,21 +87,59 @@ Povinné tematické okruhy:
 
 Zprávu zařadit pouze tehdy, pokud lze vysvětlit konkrétní dopad na rozpočet, produkci, marketing, ticketing, bezpečnost nebo návštěvnický zážitek LIR.
 
+## DnB scéna
+
+Sekce `dnb_scene` je povinný redakční blok, nikoli doplněk festivalových zpráv. Každý týden projít zdroje napříč mainstreamem, undergroundem a hlavními subžánry a vybrat nejméně dvě nejsilnější scénové změny.
+
+Zachytit zejména:
+
+- významné kariérní posuny interpretů, nové projekty, návraty, rozpady a změny sestav;
+- nové labely, přesuny mezi labely, akvizice, distribuční změny a nové kurátorské směry;
+- alba, EP a spolupráce, pokud představují výrazný kreativní, komerční nebo subžánrový posun;
+- nové live show, tour koncepty, AV formáty, významné crossover momenty a růst DnB na nových trzích;
+- rozhovory a profily obsahující skutečné informace o fungování scény, tvorbě, kreditech, zastoupení nebo ekonomice;
+- změny vkusu, nástup nových jmen, návrat staršího zvuku a témata, která se opakují napříč médii, sety a komunitou.
+
+Pouhá vazba na festival není podmínkou. `why_it_matters` může vysvětlovat dopad na booking, dramaturgii, LIR Recordings, marketing, obsah nebo orientaci ve scéně.
+
+## Reddit r/DnB
+
+Při každém běhu povinně projít veřejné přehledy Redditu `r/DnB` v režimech Hot a Top za poslední týden. Doplnit kontrolu nových vláken z reportovacího období, aby pozdě publikované diskuse nebyly znevýhodněné.
+
+Z kandidátů vybrat nejméně dvě nejsilnější diskuse podle kombinace:
+
+- počtu a kvality komentářů;
+- skóre a relativní viditelnosti vůči ostatním vláknům daného týdne;
+- novosti tématu a šíře názorů;
+- významu pro hudební vkus, subžánry, interprety, produkci, chování publika nebo fungování scény.
+
+Vyřadit prosté identifikace tracku, izolované meme, vlastní promo bez diskuse, duplicitní příspěvky a otázky s několika povrchními odpověďmi. Každá zařazená položka musí odkázat přímo na vlákno, uvést stav skóre a počtu komentářů v době sběru a shrnout hlavní názorové proudy. Reddit dokládá existenci a intenzitu debaty, nikoli tvrdá fakta.
+
+Pokud nelze získat alespoň dvě kvalifikované diskuse nebo je Reddit nedostupný, běh se nesmí publikovat. Výstup musí vrátit chybu pokrytí.
+
 ## Výběrový filtr
 
-Každého kandidáta interně posoudit podle čtyř kritérií. Hodnocení se na webu nezobrazuje.
+Každého kandidáta interně posoudit podle tří společných kritérií a jednoho kritéria podle sekce. Hodnocení se na webu nezobrazuje.
 
-- dopad na Let It Roll: 0 až 3 body;
+Společná kritéria:
+
 - novost oproti posledním čtyřem briefingům: 0 až 2 body;
 - síla důkazů: 0 až 2 body;
 - rozsah nebo význam změny: 0 až 2 body.
 
-Zařadit položky se součtem nejméně 5 bodů. Výjimkou je bezprostřední bezpečnostní, reputační nebo termínové riziko pro LIR.
+Sekční kritérium:
+
+- `competition` a `festival_industry`: konkrétní dopad na Let It Roll, 0 až 3 body;
+- `dnb_scene` a `strategic_releases`: význam pro vývoj DnB scény, booking, dramaturgii, label nebo obsah, 0 až 3 body;
+- `audience_sentiment`: relativní engagement, kvalita diskuse a šíře názorů, 0 až 3 body;
+- `cz_sk`: význam pro lokální scénu nebo obchodní prostředí, 0 až 3 body.
+
+Zařadit položky se součtem nejméně 5 bodů. Scénové a komunitní zprávy se nesmějí vyřadit jen proto, že nemají okamžitý provozní dopad na LIR. Výjimkou z bodového prahu je bezprostřední bezpečnostní, reputační nebo termínové riziko.
 
 Nezařazovat:
 
-- běžný release bez festivalového nebo bookingového dopadu;
-- rozhovor, který pouze propaguje nové album;
+- běžný release bez širšího významu pro interpreta, label, subžánr, booking nebo publikum;
+- rozhovor, který pouze opakuje promo tvrzení k novému albu a nepřináší scénovou informaci;
 - rutinní klubovou pozvánku nebo lokální seznam akcí;
 - samotný lineup bez analýzy strategie a konkurenčního dopadu;
 - recyklované oznámení bez nové informace;
@@ -110,7 +150,7 @@ Nezařazovat:
 
 ### DnB a elektronická scéna
 
-Oficiální weby a sociální kanály festivalů, promotérů, labelů a interpretů; DJ Mag; Mixmag; Resident Advisor; UKF; Drum & Bass UK; LoveThatBass; Best Drum & Bass; Drumandbass.nl; Dogs On Acid; Beatportal.
+Povinný týdenní sweep: UKF; Drum & Bass UK; DJ Mag; Mixmag; Resident Advisor; Beatportal; Data Transmission DnB; LoveThatBass; Dogs On Acid; Drumandbass.nl; Best Drum & Bass. Doplnit oficiální weby a veřejné sociální kanály relevantních labelů a interpretů. Nespoléhat jen na obecné zpravodajské vyhledávání, protože zvýhodňuje festivaly a mainstreamová média.
 
 ### Festivalový průmysl
 
@@ -122,9 +162,9 @@ DNBe HearD; Hoofbeats; Musicserver; Rave.cz; GoOut; oficiální weby a kanály f
 
 ### Komunitní sentiment
 
-Reddit `r/DnB`, `r/LetItRollFestival`, `r/Rampagefestival` a relevantní veřejná diskusní vlákna. Komunitní zdroj nesmí být jediným důkazem tvrdého faktu.
+Reddit `r/DnB` je povinný každý týden. Do `sources_scanned` zapsat `Reddit r/DnB: hot + top/week`. Pro festivalový sentiment dále sledovat `r/LetItRollFestival`, `r/Rampagefestival` a další relevantní veřejná diskusní vlákna. Komunitní zdroj nesmí být jediným důkazem tvrdého faktu.
 
-Sentiment shrnout pouze při opakujícím se vzorci ve více komentářích nebo zdrojích. Uvést, co lidé chválí, co kritizují, zda jsou názory rozdělené a jaká provozní nebo obchodní lekce z toho plyne. Jednotlivý virální komentář nestačí.
+U obecných DnB debat shrnout hlavní názorové proudy, míru shody, sporné body a význam pro scénu. U festivalového sentimentu uvést, co lidé chválí, co kritizují, zda jsou názory rozdělené a jaká provozní nebo obchodní lekce z toho plyne. Jednotlivý virální komentář nestačí.
 
 ## Ověření
 
@@ -148,12 +188,12 @@ Sentiment shrnout pouze při opakujícím se vzorci ve více komentářích nebo
 - `executive_summary` obsahuje 3 až 5 bodů vhodných k přednesení na poradě bez čtení celého webu.
 - `competition` obsahuje zpravidla 2 až 5 položek.
 - `festival_industry` obsahuje zpravidla 1 až 4 položky.
-- `dnb_scene` obsahuje nejvýše 3 strategické položky.
-- `cz_sk` obsahuje 1 až 3 položky, pokud existují skutečně relevantní změny.
-- `audience_sentiment` obsahuje nejvýše 3 doložené vzorce.
+- `dnb_scene` obsahuje 2 až 4 nejsilnější scénové položky.
+- `cz_sk` obsahuje 0 až 3 položky podle skutečné relevance.
+- `audience_sentiment` obsahuje 2 až 3 položky; nejméně dvě musí vycházet z kvalifikovaných diskusí na `r/DnB`.
 - `strategic_releases` obsahuje 0 až 2 položky.
 - `lir_actions` shrnuje 3 až 5 konkrétních úkolů z celého briefingu.
-- Minimální počty se nevynucují. Prázdná sekce je lepší než výplň.
+- Od týdne 29 roku 2026 se vynucuje minimální pokrytí `dnb_scene` a `r/DnB`. Nedostatečný sběr je chyba běhu, ne omluva pro prázdnou sekci.
 - Žádná výplň, obecné promo formulace ani duplicity z předchozího týdne bez nové informace.
 
 ## Publikační postup
@@ -162,9 +202,10 @@ Sentiment shrnout pouze při opakujícím se vzorci ve více komentářích nebo
 2. Vytvořit `news/YYYY-week_N.json` ve schématu verze 2. Číslo týdne odpovídá zpracovanému období, nikoli dni spuštění.
 3. Přidat nový záznam na začátek `news/index.json`.
 4. Zkontrolovat JSON, duplicity, data, odkazy a všechna povinná pole.
-5. Vytvořit větev `automation/briefing-YYYY-week-N`.
-6. Zapsat pouze nový briefing a manifest.
-7. Otevřít nedraftový pull request s názvem `Add DnB briefing YYYY week N`.
-8. Workflow `.github/workflows/validate-briefing.yml` zkontroluje celý datový archiv.
-9. Pull request zůstane připravený ke sloučení. Automatické sloučení vyžaduje samostatné schválení zápisových oprávnění.
-10. Pokud validace selže, nic neobcházet a vrátit přesný seznam chyb.
+5. Provést kontrolu pokrytí: nejméně 2 položky v `dnb_scene`, nejméně 2 přímé odkazy na kvalifikované diskuse z `r/DnB` v `audience_sentiment` a záznam `Reddit r/DnB: hot + top/week` v `sources_scanned`.
+6. Vytvořit větev `automation/briefing-YYYY-week-N`.
+7. Zapsat pouze nový briefing a manifest.
+8. Otevřít nedraftový pull request s názvem `Add DnB briefing YYYY week N`.
+9. Workflow `.github/workflows/validate-briefing.yml` zkontroluje celý datový archiv.
+10. Pull request zůstane připravený ke sloučení. Automatické sloučení vyžaduje samostatné schválení zápisových oprávnění.
+11. Pokud validace selže, nic neobcházet a vrátit přesný seznam chyb.

--- a/news/2026-week_28.json
+++ b/news/2026-week_28.json
@@ -7,13 +7,13 @@
     "window_end": "2026-07-12",
     "generated_at": "2026-07-13T06:31:28+02:00"
   },
-  "headline": "Poptávka po cestování za hudbou roste, slabší festivaly však dál narážejí na náklady, hluk a provozní rizika",
+  "headline": "Úmrtí Lenzmana zasáhlo DnB scénu, zatímco AI obsah a provozní tlaky mění hudební i festivalové prostředí",
   "executive_summary": [
-    "Britský live sektor v roce 2025 přilákal rekordních 24,7 milionu hudebních turistů a vytvořil útratu 11,2 miliardy liber. Pro LIR je to potvrzení, že destination positioning a zahraniční návštěvníci mají vyšší strategickou hodnotu než čistě lokální zásah.",
-    "Discovery Festivals odložily ročník 2026 kvůli růstu nákladů, slabší disponibilní kupní síle a konkurenci dalších lokálních akcí. Kombinace drahé produkce a pozdního rozhodování publika zůstává hlavním obchodním rizikem středně velkých festivalů.",
-    "Povolování Rabbits Eat Lettuce ukazuje, že nízkofrekvenční basový hluk může ohrozit dlouhodobé fungování festivalu i při prokazatelném ekonomickém přínosu regionu. Pro LIR je nutné mít měřitelný hlukový model a aktivní vztah s okolními obcemi.",
-    "Po úmrtí osmnáctileté návštěvnice Tonnau Festival zrušil zbytek programu a uvolnil areál pro vyšetřování. Událost potvrzuje nutnost předem připraveného rozhodovacího protokolu pro zastavení programu, komunikaci a odchod návštěvníků.",
-    "Evropská vedra pokračují s vysokou zdravotní zátěží a požáry. LIR musí posuzovat horko jako plnohodnotný scénář provozní kontinuity, ne jen jako komfortní problém."
+    "Úmrtí Lenzmana po dlouhé nemoci zasáhlo liquid drum and bass i komunitu kolem The North Quarter. Pro LIR je důležité rychle ověřit případné bookingové vazby a zvolit citlivou, scéně přiměřenou komunikaci.",
+    "Jedna z nejaktivnějších diskuzí týdne na r/DnB řešila podezření na AI obsahové farmy v jungle a DnB kanálech na YouTube. Publikum reaguje návratem k důvěryhodným labelům, DJům, tracklistům a lidské kuraci.",
+    "Pozitivní ohlas na track postavený ze zvuku rozbitého dřezu ukázal opačný pól stejného trendu: viditelný lidský proces a nápad mají v komunitě větší hodnotu než anonymní objem uhlazeného obsahu.",
+    "Britský live sektor v roce 2025 přilákal rekordních 24,7 milionu hudebních turistů a vytvořil útratu 11,2 miliardy liber. Pro LIR to potvrzuje strategickou hodnotu destination positioningu a zahraničních návštěvníků.",
+    "Odklady festivalů, spor o basový hluk, kritická zdravotní událost a evropská vedra dál zvyšují provozní tlak. LIR potřebuje měřitelné spouštěče pro ekonomiku, hluk, medical i extrémní počasí."
   ],
   "sections": [
     {
@@ -195,7 +195,77 @@
     {
       "id": "dnb_scene",
       "title": "DnB scéna",
-      "items": []
+      "items": [
+        {
+          "id": "lenzman-dies-north-quarter-legacy",
+          "published_at": "2026-07-12",
+          "event_start": null,
+          "event_end": null,
+          "title": "Lenzmanovo úmrtí zasáhlo liquid drum and bass a komunitu The North Quarter",
+          "summary": [
+            "Rodina Lenzmana 12. července oznámila, že nizozemský producent a DJ zemřel po tři a půl roku trvajícím boji s rakovinou ledvin.",
+            "Lenzman byl zakladatelem labelu The North Quarter a jednou z určujících osobností soulful a liquid drum and bassu.",
+            "Reakce scény zdůrazňují nejen jeho katalog, ale také roli kurátora, mentora a tvůrce komunity kolem labelu."
+          ],
+          "why_it_matters": "Ztráta výrazné osobnosti mění kontext komunikace, programu i vztahů v části DnB scény. Pro LIR je relevantní ověřit případné bookingové závazky a reagovat způsobem, který respektuje komunitu i pozůstalé.",
+          "recommended_action": "Ověřit všechny přímé vazby na booking a připravit pouze citlivou, interně schválenou vzpomínkovou komunikaci.",
+          "region": "europe",
+          "category": "dnb_scene",
+          "competitors": [],
+          "confidence": "confirmed",
+          "sources": [
+            {
+              "name": "DJ Mag",
+              "url": "https://djmag.com/news/lenzman-north-quarter-founder-and-drum-bass-stalwart-dies",
+              "kind": "secondary"
+            },
+            {
+              "name": "Resident Advisor",
+              "url": "https://ra.co/news/85562",
+              "kind": "secondary"
+            }
+          ],
+          "media": [],
+          "tags": [
+            "Lenzman",
+            "The North Quarter",
+            "liquid drum and bass",
+            "scene legacy"
+          ]
+        },
+        {
+          "id": "arky-waters-debut-bass-album",
+          "published_at": "2026-07-07",
+          "event_start": null,
+          "event_end": null,
+          "title": "Arky Waters debutovým albem Holdin’ On vstupuje naplno do bass music",
+          "summary": [
+            "Australský producent Arky Waters vydal u Mammal Sounds Records debutové album Holdin’ On, které označuje za svůj první plný vstup do bass music.",
+            "Projekt vychází ze zkušeností sydneyské klubové scény a propojuje osobní témata s experimentálním sound designem.",
+            "Focus track Take a Trip vznikl s vokalistou LX a ukazuje, jak se regionální producent může přes crossover zvuk dostat do širšího bassového prostoru."
+          ],
+          "why_it_matters": "Nejde o okamžitý headline booking, ale o užitečný signál z australského trhu a o typ crossover projektu, který může v horizontu měsíců vyrůst do relevantního klubového nebo labelového partnerství.",
+          "recommended_action": "Zařadit Arky Waters do šestíměsíčního watchlistu a sledovat streaming, support DJů a evropské bookingové kroky.",
+          "region": "world",
+          "category": "dnb_scene",
+          "competitors": [],
+          "confidence": "probable",
+          "sources": [
+            {
+              "name": "Data Transmission DnB",
+              "url": "https://datatransmission.co/dt-dnb/australian-producer-arky-waters-releases-debut-album-holdin-on/",
+              "kind": "secondary"
+            }
+          ],
+          "media": [],
+          "tags": [
+            "Arky Waters",
+            "Australia",
+            "bass music",
+            "emerging artist"
+          ]
+        }
+      ]
     },
     {
       "id": "cz_sk",
@@ -205,12 +275,117 @@
     {
       "id": "audience_sentiment",
       "title": "Sentiment publika",
-      "items": []
+      "items": [
+        {
+          "id": "reddit-ai-dnb-content-farms",
+          "published_at": "2026-07-06",
+          "event_start": null,
+          "event_end": null,
+          "title": "r/DnB řeší příval podezřelých AI kanálů a ztrátu důvěry v hudební discovery",
+          "summary": [
+            "Vlákno bylo při pondělním skenu r/DnB Top za týden mezi nejaktivnějšími příspěvky se zhruba 354 hlasy a 124 komentáři.",
+            "Autor a část diskutujících podezírají rychle publikující jungle a DnB kanály na YouTube z používání generativní AI a obsahových farem; konkrétní obvinění však nejsou nezávisle ověřena.",
+            "Nejčastější reakcí je návrat k zavedeným labelům, skutečným DJům, tracklistům, odběrům a komunitně kurátorovaným zdrojům místo algoritmického feedu.",
+            "Diskuze není jednotná: někteří uživatelé část této estetiky stále oceňují nebo odmítají dělat závěry bez důkazů."
+          ],
+          "why_it_matters": "Pro LIR a LIR Recordings roste hodnota jasně doloženého lidského autorství, kreditu a kurace. Důvěra v původ obsahu se stává součástí značky, ne jen produkčním detailem.",
+          "recommended_action": "U nového hudebního a video obsahu systematicky uvádět autory, kredity, tracklisty a krátký doklad tvůrčího procesu.",
+          "region": "global",
+          "category": "audience_sentiment",
+          "competitors": [],
+          "confidence": "unverified",
+          "sources": [
+            {
+              "name": "Reddit r/DnB",
+              "url": "https://www.reddit.com/r/DnB/comments/1up0qan/im_noticing_a_trend_here/",
+              "kind": "community"
+            }
+          ],
+          "media": [],
+          "tags": [
+            "Reddit",
+            "AI music",
+            "discovery",
+            "trust"
+          ]
+        },
+        {
+          "id": "reddit-broken-sink-dnb-production",
+          "published_at": "2026-07-07",
+          "event_start": null,
+          "event_end": null,
+          "title": "Track ze zvuku rozbitého dřezu ukázal sílu viditelného lidského procesu",
+          "summary": [
+            "Příspěvek i turned that broken sink sample into dnb získal při pondělním skenu přibližně 472 hlasů a 90 komentářů.",
+            "Autor proměnil běžný zvuk rozbitého dřezu v základ DnB tracku a doplnil odkaz na plnou verzi.",
+            "Reakce byly převážně pozitivní, často zmiňovaly podobnost s tvorbou Venjent a žádaly další experimenty s nalezenými zvuky.",
+            "Úspěch příspěvku stojí na srozumitelném nápadu, viditelném procesu a autenticitě, nikoli na anonymní produkční dokonalosti."
+          ],
+          "why_it_matters": "Komunita pozitivně reaguje na obsah, který rychle ukáže původ nápadu a lidské řemeslo. To je přímo použitelný formát pro organický obsah festivalu i labelu.",
+          "recommended_action": "Otestovat jeden krátký procesní formát LIR Recordings, který ukáže vznik konkrétního zvuku od nahrávky po hotový drop.",
+          "region": "global",
+          "category": "audience_sentiment",
+          "competitors": [],
+          "confidence": "probable",
+          "sources": [
+            {
+              "name": "Reddit r/DnB",
+              "url": "https://www.reddit.com/r/DnB/comments/1uq31ly/i_turned_that_broken_sink_sample_into_dnb/",
+              "kind": "community"
+            }
+          ],
+          "media": [],
+          "tags": [
+            "Reddit",
+            "found sound",
+            "production",
+            "authenticity"
+          ]
+        }
+      ]
     },
     {
       "id": "strategic_releases",
       "title": "Strategické releasy",
-      "items": []
+      "items": [
+        {
+          "id": "kanine-wide-awake-ukf-release",
+          "published_at": "2026-07-08",
+          "event_start": null,
+          "event_end": null,
+          "title": "Kanine pokračuje v dancefloor releasové linii singlem Wide Awake na UKF",
+          "summary": [
+            "UKF zveřejnilo 8. července nový singl Wide Awake od britského producenta Kanine.",
+            "Jednoskladbový release potvrzuje pokračující viditelnost Kanine v jednom z hlavních mediálních a distribučních kanálů současného drum and bassu.",
+            "Pro festivalový booking je důležitější pravidelnost jeho releasového cyklu a dosah ekosystému UKF než samotná existence jednoho singlu."
+          ],
+          "why_it_matters": "Kanine patří k relevantním dancefloor jménům pro LIR. Nový release pomáhá držet jeho aktuálnost a může podpořit načasování bookingové nebo obsahové komunikace.",
+          "recommended_action": "Promítnout nový singl do artist watchlistu a případné komunikace, pokud je Kanine součástí aktuálního nebo připravovaného programu.",
+          "region": "europe",
+          "category": "strategic_release",
+          "competitors": [],
+          "confidence": "confirmed",
+          "sources": [
+            {
+              "name": "UKF",
+              "url": "https://ukf.com/listen/releases/wide-awake/",
+              "kind": "primary"
+            },
+            {
+              "name": "Drum & Bass UK",
+              "url": "https://drumandbassuk.com/artist/kanine/wide-awake-64338",
+              "kind": "secondary"
+            }
+          ],
+          "media": [],
+          "tags": [
+            "Kanine",
+            "UKF",
+            "dancefloor",
+            "release"
+          ]
+        }
+      ]
     },
     {
       "id": "lir_actions",
@@ -332,6 +507,41 @@
             "heatwave",
             "operations"
           ]
+        },
+        {
+          "id": "lir-action-human-provenance-content",
+          "published_at": "2026-07-12",
+          "event_start": null,
+          "event_end": null,
+          "title": "Zviditelnit lidský původ hudebního obsahu",
+          "summary": [
+            "Spojit jasné kredity a tracklisty s krátkým procesním obsahem, který ukazuje vznik konkrétního zvuku nebo skladby."
+          ],
+          "why_it_matters": "r/DnB současně ukazuje nedůvěru k anonymnímu AI obsahu a silnou pozitivní reakci na viditelný lidský nápad a řemeslo.",
+          "recommended_action": "Připravit jeden pilotní formát pro LIR Recordings a vyhodnotit dokončení videa, sdílení a kvalitativní reakce.",
+          "region": "global",
+          "category": "lir_action",
+          "competitors": [],
+          "confidence": "probable",
+          "sources": [
+            {
+              "name": "Reddit r/DnB — AI discussion",
+              "url": "https://www.reddit.com/r/DnB/comments/1up0qan/im_noticing_a_trend_here/",
+              "kind": "community"
+            },
+            {
+              "name": "Reddit r/DnB — found sound",
+              "url": "https://www.reddit.com/r/DnB/comments/1uq31ly/i_turned_that_broken_sink_sample_into_dnb/",
+              "kind": "community"
+            }
+          ],
+          "media": [],
+          "tags": [
+            "content",
+            "provenance",
+            "AI",
+            "LIR Recordings"
+          ]
         }
       ]
     }
@@ -346,6 +556,12 @@
     "Associated Press",
     "Courier Mail",
     "The Sun",
-    "UK Music"
+    "UK Music",
+    "DJ Mag",
+    "Resident Advisor",
+    "Data Transmission DnB",
+    "UKF",
+    "Drum & Bass UK",
+    "Reddit r/DnB: hot + top/week"
   ]
 }

--- a/scripts/validate_briefing.py
+++ b/scripts/validate_briefing.py
@@ -25,6 +25,7 @@ REGIONS = {"world", "europe", "cz_sk", "global"}
 CONFIDENCE = {"confirmed", "probable", "unverified"}
 SOURCE_KINDS = {"primary", "secondary", "community"}
 MEDIA_TYPES = {"image", "instagram", "youtube", "spotify", "soundcloud"}
+EDITORIAL_COVERAGE_START = (2026, 29)
 
 
 class ValidationError(Exception):
@@ -83,6 +84,13 @@ def validate_media(value: dict, field: str) -> None:
     if value["type"] not in MEDIA_TYPES:
         fail(f"{field}.type is invalid")
     https_url(value["url"], f"{field}.url")
+
+
+def is_reddit_dnb_url(value: str) -> bool:
+    parsed = urlparse(value)
+    host = parsed.netloc.casefold().split(":")[0]
+    path = parsed.path.casefold()
+    return (host == "reddit.com" or host.endswith(".reddit.com")) and path.startswith("/r/dnb/")
 
 
 def validate_unique_text_list(value, field: str, maximum: int, max_text: int = 80) -> None:
@@ -214,6 +222,24 @@ def validate_v2(path: Path, report: dict) -> list[str]:
         validate_unique_text_list(report["sources_scanned"], "sources_scanned", 100, 120)
         if not report["sources_scanned"]:
             fail("sources_scanned must not be empty")
+
+        if (period["year"], period["week"]) >= EDITORIAL_COVERAGE_START:
+            section_map = {section["id"]: section["items"] for section in sections}
+            if len(section_map["dnb_scene"]) < 2:
+                fail("dnb_scene must contain at least 2 items")
+
+            reddit_items = [
+                item
+                for item in section_map["audience_sentiment"]
+                if any(is_reddit_dnb_url(source["url"]) for source in item["sources"])
+            ]
+            if len(reddit_items) < 2:
+                fail("audience_sentiment must contain at least 2 items sourced from Reddit r/DnB")
+
+            scan_labels = [label.casefold() for label in report["sources_scanned"]]
+            if not any("reddit" in label and "r/dnb" in label and "top/week" in label for label in scan_labels):
+                fail("sources_scanned must record the Reddit r/DnB hot + top/week sweep")
+
         return []
     except ValidationError as exc:
         return [f"{path.relative_to(ROOT)}: {exc}"]


### PR DESCRIPTION
## Co se mění

- DnB scéna, festivalová konkurence a festivalový průmysl jsou nově rovnocenné obsahové pilíře.
- Každý týden je povinný sweep specializovaných DnB médií.
- Každý týden se kontroluje r/DnB v režimu Hot, Top za týden a relevantní nové příspěvky.
- Od týdne 29 validátor vyžaduje minimálně 2 položky v sekci DnB scéna a 2 přímé r/DnB diskuze v sentimentu.
- Reddit položky musí uvádět stav hlasů a komentářů v době skenu a shrnout hlavní názorové proudy.
- Scénická zpráva už nemusí mít okamžitý provozní dopad na LIR, pokud je důležitá pro žánr, labely, artists nebo publikum.

## Oprava týdne 28

Aktuální briefing je doplněn o:

- úmrtí Lenzmana a dopad na komunitu The North Quarter,
- debutové bass album Arky Waters,
- release Kanine — Wide Awake,
- r/DnB diskuzi o podezřelých AI obsahových farmách (cca 354 hlasů / 124 komentářů při skenu),
- r/DnB produkční post se samplem rozbitého dřezu (cca 472 hlasů / 90 komentářů při skenu).

U komunitních tvrzení je výslovně rozlišen sentiment od ověřeného faktu.

## Kontrola

- validace schématu a historických briefingů přes GitHub Actions
- změna zůstává v PR bez automatického merge