### PR TITLE
Update week 28 covers and card proportions

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,12 +38,31 @@
       backdrop-filter: blur(10px);
     }
     .news-card:last-child { margin-bottom: 1rem; }
-    .cover { aspect-ratio: 16 / 9; }
+    .cover {
+      display: block;
+      width: 100%;
+      height: auto;
+      aspect-ratio: 4 / 5;
+      object-fit: cover;
+    }
     .media-frame { width: 100%; border: 0; border-radius: .75rem; background: white; }
     @media (min-width: 768px) {
-      .news-card.has-cover .cover-wrap { width: 40%; }
-      .news-card.has-cover .card-body { width: 60%; }
-      .news-card.has-cover .cover { min-height: 100%; aspect-ratio: auto; }
+      .news-card.has-cover { align-items: stretch; }
+      .news-card.has-cover .cover-wrap {
+        display: flex;
+        flex: 0 0 38%;
+        width: 38%;
+        align-items: flex-start;
+      }
+      .news-card.has-cover .card-body {
+        flex: 0 0 62%;
+        width: 62%;
+      }
+      .news-card.has-cover .cover {
+        height: auto;
+        min-height: 0;
+        aspect-ratio: 4 / 5;
+      }
     }
   </style>
 </head>
@@ -226,7 +245,7 @@
         <article class="news-card group mx-auto flex max-w-5xl flex-col overflow-hidden rounded-xl md:flex-row ${image ? "has-cover" : ""}">
           ${image ? `
             <div class="cover-wrap w-full p-6 md:p-8">
-              <img class="cover h-full w-full rounded-xl object-cover shadow-lg transition-transform duration-500 group-hover:scale-[1.02]"
+              <img class="cover w-full rounded-xl object-cover shadow-lg transition-transform duration-500 group-hover:scale-[1.02]"
                 src="${esc(image)}" alt="${esc(item.title || "")}" loading="lazy" referrerpolicy="no-referrer">
             </div>` : ""}
           <div class="card-body flex w-full flex-col justify-between p-6 ${image ? "pt-0 md:pl-0 md:pt-8" : "md:p-10"}">

--- a/news/2026-week_28.json
+++ b/news/2026-week_28.json
@@ -182,6 +182,10 @@
           ],
           "media": [
             {
+              "type": "image",
+              "url": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR-iUKBssb-SOxhKgRFTtvuYsKTXItmimkmP3o6ZkPWJQ&s"
+            },
+            {
               "type": "instagram",
               "url": "https://www.instagram.com/worship_/reel/Daq3R7_NNA8/"
             }
@@ -232,7 +236,7 @@
           "media": [
             {
               "type": "image",
-              "url": "https://imgproxy.ra.co/_/quality%3A66/aHR0cHM6Ly9zdGF0aWMucmEuY28vaW1hZ2VzL25ld3MvMjAyNi9sZW56enoucG5n"
+              "url": "https://djmag.com/sites/default/files/styles/djm_23_1005x565/public/2026-07/746021218_18606809179006539_1753983369814435251_n.jpg.webp?itok=dHBaPtxX"
             },
             {
               "type": "youtube",
@@ -285,7 +289,7 @@
           "media": [
             {
               "type": "image",
-              "url": "https://external-preview.redd.it/ZGd6eDBzdzRtdWJoMfWNxMgYwpHxuinx048xhDqtpcDeeO3pxE5NoZA_vX9j.png?format=pjpg&auto=webp&s=6ea4fc8fd4b88d57a66091b00b61d750d390460e"
+              "url": "https://preview.redd.it/moms-broken-sink-v0-8nwuax4udjhd1.jpg?width=640&crop=smart&auto=webp&s=ab680060c9e88a6443167f3ed36db223b39428b1"
             },
             {
               "type": "youtube",


### PR DESCRIPTION
## Změny

- nový zadaný obrázek u Lenzmana,
- nový zadaný obrázek u Phantoma / vlákna o rozbitém umyvadlu,
- nový titulní obrázek u Worshipu,
- všechny titulní obrázky mají poměr stran 4:5,
- na desktopu je obrázek vlevo (38 %) a text vpravo (62 %),
- obrázek se už nenatahuje podle délky článku,
- na mobilu se karta skládá pod sebe.

## Kontrola

- ověřeny přesné URL všech tří obrázků,
- ověřen poměr 4:5 a levé umístění,
- JavaScript prošel syntaktickou kontrolou,
- automatický merge není zapnutý.