### PR TITLE
Polish week 29 media and add Chase & Status

### DIFF
--- a/AUTOMATION.md
+++ b/AUTOMATION.md
@@ -171,6 +171,7 @@ U obecných DnB debat shrnout hlavní názorové proudy, míru shody, sporné bo
 - Každý tvrdý fakt musí mít primární zdroj nebo dva nezávislé sekundární zdroje.
 - Reddit a komentáře dokazují sentiment, nikoli návštěvnost, finance nebo oficiální rozhodnutí.
 - Datum publikace patří do `published_at`. Datum konání patří do `event_start` a `event_end`.
+- Pondělní zprávu lze výjimečně zařadit do předchozího týdne, pouze pokud popisuje událost z jeho neděle. `published_at` musí zůstat pravdivé a `event_start` musí doložit datum události v reportovacím období.
 - Neověřená tvrzení mají `confidence: unverified` a nesmějí být formulována jako fakta.
 - Nepoužívat Wikipedii jako hlavní zdroj nové zprávy.
 - Nepoužívat Google image cache, dočasné Instagram CDN adresy ani obrázky bez dohledatelného původu.

--- a/index.html
+++ b/index.html
@@ -45,7 +45,10 @@
       aspect-ratio: 4 / 5;
       object-fit: cover;
     }
-    .media-frame { width: 100%; border: 0; border-radius: .75rem; background: white; }
+    .media-frame { display: block; width: 100%; border: 0; border-radius: .75rem; background: transparent; }
+    .instagram-embed { width: 100%; max-width: 540px; margin: 1.25rem auto; }
+    .instagram-frame { height: 460px; }
+    .spotify-frame { min-height: 152px; }
     @media (min-width: 768px) {
       .news-card.has-cover { align-items: stretch; }
       .news-card.has-cover .cover-wrap {
@@ -191,8 +194,8 @@
         if (!match) return "";
         const canonical = `https://www.instagram.com/${match[1]}/${match[2]}/`;
         return `
-          <div class="my-5 rounded-xl border border-slate-700 bg-slate-900/60 p-3">
-            <iframe class="media-frame" height="620" loading="lazy" scrolling="no" src="${canonical}embed"></iframe>
+          <div class="instagram-embed rounded-xl border border-slate-700 bg-slate-900/60 p-3">
+            <iframe class="media-frame instagram-frame" loading="lazy" scrolling="no" src="${canonical}embed"></iframe>
             <p class="mt-3 text-center text-sm text-slate-400">
               Pokud se příspěvek nenačte, <a class="text-pink-400 hover:underline" href="${canonical}" target="_blank" rel="noopener noreferrer">otevřít Instagram</a>.
             </p>
@@ -213,9 +216,10 @@
         const match = url.match(/spotify\.com\/(track|album)\/([^/?]+)/);
         return match ? `
           <div class="my-5">
-            <iframe class="media-frame" height="${match[1] === "album" ? 352 : 152}" loading="lazy"
+            <iframe class="media-frame spotify-frame" height="${match[1] === "album" ? 352 : 152}"
+              title="Spotify přehrávač" loading="eager" allowfullscreen
               allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-              src="https://open.spotify.com/embed/${match[1]}/${esc(match[2])}"></iframe>
+              src="https://open.spotify.com/embed/${match[1]}/${esc(match[2])}?utm_source=generator&theme=0"></iframe>
           </div>` : "";
       }
 

--- a/news/2026-week_29.json
+++ b/news/2026-week_29.json
@@ -5,10 +5,11 @@
     "week": 29,
     "window_start": "2026-07-13",
     "window_end": "2026-07-19",
-    "generated_at": "2026-07-20T06:30:02+02:00"
+    "generated_at": "2026-07-20T12:35:00+02:00"
   },
-  "headline": "Liquicity míří k vyprodání, Tomorrowland zakázal pyrotechniku a Pohoda hlásí rekordní předprodej",
+  "headline": "Chase & Status debutovali na Tomorrowlandu a příští víkend zamíří na Mainstage",
   "executive_summary": [
+    "Chase & Status odehráli svůj první set na Tomorrowlandu a 26. července se na festival vrátí s debutem na Mainstage.",
     "Liquicity Festival vydal poslední varování před vyprodáním poté, co počet zbývajících víkendových vstupenek klesl pod sto.",
     "Tomorrowland nesměl během prvního víkendu použít ohňostroje ani pódiovou pyrotechniku kvůli zvýšenému požárnímu riziku.",
     "Pohoda po vyprodaném jubilejním ročníku prodala během pěti dnů přes deset tisíc vstupenek na rok 2027.",
@@ -96,6 +97,33 @@
       "id": "dnb_scene",
       "title": "DnB scéna",
       "items": [
+        {
+          "id": "chase-status-tomorrowland-debut-2026",
+          "published_at": "2026-07-20",
+          "event_start": "2026-07-19",
+          "event_end": null,
+          "title": "Chase & Status debutovali na Tomorrowlandu",
+          "summary": [
+            "Chase & Status odehráli během prvního víkendu Tomorrowlandu 2026 DJ set na Freedom stage. Oficiální program je zařadil na neděli 19. července od 20:00 a zveřejněné záběry zachycují silné reakce publika během jejich drum & bassového setu.",
+            "Instagramový příspěvek označuje vystoupení za premiéru dua na Tomorrowlandu a vyzdvihuje množství nevydaných skladeb a neobvyklých mixů. Hodnocení setu jako jednoho z nejlepších vystoupení dvojice je názorem autora příspěvku, nikoli ověřeným faktem.",
+            "Chase & Status se na festival vrátí v neděli 26. července s DJ setem na Mainstage. Tomorrowland je řadí mezi interprety, kteří tam letos absolvují svůj debut, takže během jednoho ročníku vystoupí na Freedom stage i hlavním pódiu."
+          ],
+          "why_it_matters": "Dvě vystoupení během jednoho ročníku ukazují výrazný posun drum & bassu do hlavního programu jednoho z největších světových elektronických festivalů.",
+          "recommended_action": "Bez akce, pouze informační přehled",
+          "region": "europe",
+          "category": "dnb_scene",
+          "competitors": [],
+          "confidence": "confirmed",
+          "sources": [
+            {"name": "Instagram", "url": "https://www.instagram.com/p/DbAszJlk4Rg/?img_index=1", "kind": "community"},
+            {"name": "Tomorrowland", "url": "https://tomorrowlandbelgium.press.tomorrowland.com/tomorrowland-unveils-the-full-line-up-and-timetable-for-consciencia-in-belgium", "kind": "primary"}
+          ],
+          "media": [
+            {"type": "image", "url": "https://www.instagram.com/p/DbAszJlk4Rg/media/?size=l"},
+            {"type": "instagram", "url": "https://www.instagram.com/p/DbAszJlk4Rg/"}
+          ],
+          "tags": ["Chase & Status", "Tomorrowland", "Freedom stage", "Mainstage", "DnB crossover"]
+        },
         {
           "id": "hedex-nu-era-laser-stage-show",
           "published_at": "2026-07-15",

--- a/news/2026-week_29.json
+++ b/news/2026-week_29.json
@@ -12,8 +12,7 @@
     "Liquicity Festival vydal poslední varování před vyprodáním poté, co počet zbývajících víkendových vstupenek klesl pod sto.",
     "Tomorrowland nesměl během prvního víkendu použít ohňostroje ani pódiovou pyrotechniku kvůli zvýšenému požárnímu riziku.",
     "Pohoda po vyprodaném jubilejním ročníku prodala během pěti dnů přes deset tisíc vstupenek na rok 2027.",
-    "Hedex oznámil nový koncertní koncept Nu Era Laser + Stage Show s premiérou na festivalu MHITR.",
-    "Protest proti vlastníkovi Boiler Room narušil dva programové dny v New Yorku a otevřel další spor o festivalové značky ovládané investiční skupinou KKR."
+    "Hedex oznámil nový koncertní koncept Nu Era Laser + Stage Show s premiérou na festivalu MHITR."
   ],
   "sections": [
     {
@@ -37,7 +36,10 @@
           "competitors": ["Liquicity Festival"],
           "confidence": "confirmed",
           "sources": [{"name": "Liquicity Festival", "url": "https://www.instagram.com/p/Da5fKfDDK-V/?img_index=5", "kind": "primary"}],
-          "media": [{"type": "instagram", "url": "https://www.instagram.com/p/Da5fKfDDK-V/"}],
+          "media": [
+            {"type": "image", "url": "https://www.instagram.com/p/Da5fKfDDK-V/media/?size=l"},
+            {"type": "instagram", "url": "https://www.instagram.com/p/Da5fKfDDK-V/"}
+          ],
           "tags": ["Liquicity", "ticket sales", "sellout", "camping"]
         }
       ]
@@ -46,30 +48,6 @@
       "id": "festival_industry",
       "title": "Festivalový průmysl",
       "items": [
-        {
-          "id": "heritage-live-cancels-2026-series",
-          "published_at": "2026-07-13",
-          "event_start": null,
-          "event_end": null,
-          "title": "Heritage Live ruší jedenáct koncertních dnů po propadu financování",
-          "summary": [
-            "Britský promotér Heritage Live zrušil celý letní program na Englefield Estate, Audley End Estate a Sandringham Estate. Na jedenácti koncertních dnech měli vystoupit mimo jiné Janet Jackson, Christina Aguilera, Eric Clapton, Lionel Richie, Faithless a The Streets.",
-            "Pořadatel uvedl, že část programu prodávala výrazně méně vstupenek než obvykle a připravovaný investiční a kapitálový balíček selhal na poslední chvíli. Pokračovat bez jistoty úhrady nákladů dodavatelům, umělcům a štábům označil za nezodpovědné.",
-            "Zrušení přišlo méně než dva týdny před prvním termínem. Oficiální prodejci mají návštěvníkům vrátit vstupné."
-          ],
-          "why_it_matters": "Případ spojuje tři současná rizika nezávislých promotérů: slabší předprodej, rostoucí náklady a nedostatek provozního kapitálu.",
-          "recommended_action": "Bez akce, pouze informační přehled",
-          "region": "europe",
-          "category": "festival_industry",
-          "competitors": [],
-          "confidence": "confirmed",
-          "sources": [
-            {"name": "Englefield Estate", "url": "https://www.englefieldestate.co.uk/whats-on/heritage-live-summer-concerts-cancelled", "kind": "primary"},
-            {"name": "Pollstar", "url": "https://news.pollstar.com/2026/07/15/uk-concert-series-hertiage-live-canceled-over-high-costs-low-ticket-sales/", "kind": "secondary"}
-          ],
-          "media": [{"type": "image", "url": "https://static.pollstar.com/wp-content/uploads/2024/11/GettyImages-1640877079-1024x579.jpg"}],
-          "tags": ["festival cancellation", "ticket sales", "financing", "United Kingdom", "refunds"]
-        },
         {
           "id": "tomorrowland-pyrotechnics-ban-weekend-one",
           "published_at": "2026-07-15",
@@ -90,27 +68,6 @@
           "sources": [{"name": "DJ Mag", "url": "https://djmag.com/news/tomorrowland-2026-fireworks-and-pyrotechnics-banned-weekend-one-due-fire-risk", "kind": "secondary"}],
           "media": [{"type": "image", "url": "https://djmag.com/sites/default/files/styles/djm_23_961x540/public/2026-07/Screenshot%202026-07-15%20at%2013.12.07.png.webp?itok=FZiZhVb4"}],
           "tags": ["Tomorrowland", "pyrotechnics", "fire risk", "weather", "safety"]
-        },
-        {
-          "id": "boiler-room-new-york-anti-kkr-protest",
-          "published_at": "2026-07-16",
-          "event_start": "2026-07-10",
-          "event_end": "2026-07-11",
-          "title": "Protest proti KKR narušil Boiler Room v New Yorku",
-          "summary": [
-            "Dva programové dny Boiler Room v brooklynském prostoru Under The K Bridge narušili demonstranti spojení s hnutím Boycott Room. Protest mířil proti vlastníkovi značky Superstruct Entertainment a jeho majiteli, investiční společnosti KKR.",
-            "Část aktivistů rozdávala před vstupem letáky, další skupina uvnitř uspořádala hromadný protest vleže. Následující den jeden z protestujících vstoupil na pódium, odpojil techniku a následně jej odvedla ochranka.",
-            "Boiler Room uznal právo na pokojný protest a uvedl, že chování jednoho návštěvníka vůči demonstrantovi nemá na jeho akcích místo. Protestní skupiny současně uspořádaly alternativní rave v Queensu."
-          ],
-          "why_it_matters": "Spor ukazuje reputační riziko, které se může přenášet z vlastníka na jednotlivé festivalové a hudební značky skupiny Superstruct.",
-          "recommended_action": "Bez akce, pouze informační přehled",
-          "region": "global",
-          "category": "festival_industry",
-          "competitors": [],
-          "confidence": "probable",
-          "sources": [{"name": "DJ Mag", "url": "https://djmag.com/news/boiler-room-new-york-event-disrupted-anti-kkr-protest-activists-allege-assault", "kind": "secondary"}],
-          "media": [{"type": "image", "url": "https://djmag.com/sites/default/files/styles/djm_23_961x540/public/2026-07/Screenshot%202026-07-16%20at%2014.30.51.png.webp?itok=AR-jR_oe"}],
-          "tags": ["Boiler Room", "Superstruct", "KKR", "protest", "reputation"]
         },
         {
           "id": "pohoda-record-presale-2027",
@@ -156,7 +113,10 @@
           "competitors": [],
           "confidence": "confirmed",
           "sources": [{"name": "Hedex", "url": "https://www.instagram.com/p/Daz6VdxqRcE/", "kind": "primary"}],
-          "media": [{"type": "instagram", "url": "https://www.instagram.com/p/Daz6VdxqRcE/"}],
+          "media": [
+            {"type": "image", "url": "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQb8KnnBLPBak1g9e7QJSWIJpjc_yaYf_LVlTb3C1REl1jKIN7gDrIBl74&s=10"},
+            {"type": "instagram", "url": "https://www.instagram.com/p/Daz6VdxqRcE/"}
+          ],
           "tags": ["Hedex", "live show", "lasers", "stage production", "MHITR"]
         },
         {
@@ -201,7 +161,7 @@
           "sources": [{"name": "UKF", "url": "https://ukf.com/listen/releases/the-rush/", "kind": "primary"}],
           "media": [
             {"type": "image", "url": "https://ukf.com/wp-content/uploads/2026/07/TSugah-TheRush-Artwork-v3-2.jpg"},
-            {"type": "spotify", "url": "https://open.spotify.com/album/2yoOGh1V1KSZuRw3AUqZNL"}
+            {"type": "spotify", "url": "https://open.spotify.com/track/78jhWm8GMFK5lxqWdXz0u5"}
           ],
           "tags": ["T & Sugah", "UKF", "dancefloor", "label move"]
         },
@@ -292,7 +252,10 @@
           "competitors": [],
           "confidence": "probable",
           "sources": [{"name": "Instagram — Pendulum a Wargasm", "url": "https://www.instagram.com/p/Da3BCf7MoMr/", "kind": "community"}],
-          "media": [{"type": "instagram", "url": "https://www.instagram.com/p/Da3BCf7MoMr/"}],
+          "media": [
+            {"type": "image", "url": "https://www.instagram.com/p/Da3BCf7MoMr/media/?size=l"},
+            {"type": "instagram", "url": "https://www.instagram.com/p/Da3BCf7MoMr/"}
+          ],
           "tags": ["Pendulum", "Wargasm", "festival performance", "audience sentiment"]
         }
       ]

--- a/scripts/validate_briefing.py
+++ b/scripts/validate_briefing.py
@@ -7,7 +7,7 @@ import argparse
 import json
 import re
 import sys
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -112,7 +112,7 @@ def validate_v2(path: Path, report: dict) -> list[str]:
         if start > end:
             fail("period.window_start is after period.window_end")
         try:
-            datetime.fromisoformat(period["generated_at"].replace("Z", "+00:00"))
+            generated_at = datetime.fromisoformat(period["generated_at"].replace("Z", "+00:00"))
         except (TypeError, ValueError):
             fail("period.generated_at must be an ISO datetime")
         expected_filename = f"{period['year']}-week_{period['week']}.json"
@@ -162,14 +162,20 @@ def validate_v2(path: Path, report: dict) -> list[str]:
                 seen_ids.add(item_id)
 
                 published = iso_date(item["published_at"], f"{field}.published_at")
-                if not start <= published <= end:
-                    fail(f"{field}.published_at is outside the reporting window")
                 event_start = iso_date(item["event_start"], f"{field}.event_start") if item["event_start"] else None
                 event_end = iso_date(item["event_end"], f"{field}.event_end") if item["event_end"] else None
                 if event_end and not event_start:
                     fail(f"{field}.event_end requires event_start")
                 if event_start and event_end and event_end < event_start:
                     fail(f"{field}.event_end is before event_start")
+                late_event_coverage = (
+                    published == end + timedelta(days=1)
+                    and published <= generated_at.date()
+                    and event_start is not None
+                    and start <= event_start <= end
+                )
+                if not start <= published <= end and not late_event_coverage:
+                    fail(f"{field}.published_at is outside the reporting window")
 
                 title = text(item["title"], f"{field}.title", 8, 180)
                 normalized = re.sub(r"\W+", " ", title.casefold()).strip()


### PR DESCRIPTION
## Co se mění

- přidává Chase & Status jako první zprávu týdne včetně náhledu a Instagram embed okna
- přidává obrázek k Hedexovi a doplňuje náhledy k Pendulum a Liquicity
- zmenšuje Instagram embedy u všech příspěvků na kompaktní rozměr
- opravuje Spotify přehrávače: eager loading a kanonický embed; T & Sugah nově odkazuje na platný track
- odstraňuje Heritage Live a protest proti KKR na Boiler Room včetně souhrnu týdne

## Pondělní doplnění

Příspěvek Chase & Status vyšel v pondělí 20. července, ale popisuje vystoupení z neděle 19. července. Validace nově dovoluje tuto úzkou výjimku jen tehdy, když je pondělní zpráva publikována bezprostředně po reportovacím období a má doložené `event_start` z jeho neděle.

## Kontrola

- `python scripts/validate_briefing.py --all`: 29 reportů, 0 chyb, 0 varování
- JavaScript v `index.html`: syntakticky validní
- `git diff --check`: bez chyb