### PR TITLE
Fix Spotify players in week 29 briefing

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,8 @@
     .media-frame { display: block; width: 100%; border: 0; border-radius: .75rem; background: transparent; }
     .instagram-embed { width: 100%; max-width: 540px; margin: 1.25rem auto; }
     .instagram-frame { height: auto; aspect-ratio: 4 / 5; }
-    .spotify-frame { min-height: 152px; }
+    .spotify-embed { overflow: hidden; border: 1px solid rgba(71, 85, 105, .72); border-radius: .75rem; background: #121212; }
+    .spotify-frame { min-height: 152px; border-radius: 0; background: #121212; }
     @media (min-width: 768px) {
       .news-card.has-cover { align-items: stretch; }
       .news-card.has-cover .cover-wrap {
@@ -215,11 +216,15 @@
       if (media.type === "spotify") {
         const match = url.match(/spotify\.com\/(track|album)\/([^/?]+)/);
         return match ? `
-          <div class="my-5">
-            <iframe class="media-frame spotify-frame" height="${match[1] === "album" ? 352 : 152}"
-              title="Spotify přehrávač" loading="eager" allowfullscreen
+          <div class="spotify-embed my-5">
+            <iframe class="media-frame spotify-frame" width="100%" height="${match[1] === "album" ? 352 : 152}"
+              title="Spotify přehrávač" loading="eager" frameborder="0" allowfullscreen=""
+              referrerpolicy="strict-origin-when-cross-origin"
               allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
-              src="https://open.spotify.com/embed/${match[1]}/${esc(match[2])}?utm_source=generator&theme=0"></iframe>
+              src="https://open.spotify.com/embed/${match[1]}/${esc(match[2])}?utm_source=generator"></iframe>
+            <p class="m-0 border-t border-slate-700 px-4 py-3 text-center text-sm text-slate-300">
+              <a class="font-semibold text-green-400 hover:underline" href="${esc(url)}" target="_blank" rel="noopener noreferrer">Otevřít ve Spotify</a>
+            </p>
           </div>` : "";
       }
 

--- a/news/2026-week_29.json
+++ b/news/2026-week_29.json
@@ -169,7 +169,7 @@
           "sources": [{"name": "Kmag", "url": "https://kmag.co.uk/premiere-keep-it-running-with-the-debut-lp-from-unknown-face-soul-in-motion/", "kind": "secondary"}],
           "media": [
             {"type": "image", "url": "https://kmag.co.uk/wp-content/uploads/2026/07/SIMLP001-WEB-SQUARE-e1783970452952.jpg"},
-            {"type": "spotify", "url": "https://open.spotify.com/album/2hu08BPeB4DQVFNC8leHUN"}
+            {"type": "spotify", "url": "https://open.spotify.com/album/2hu08BPeB4DQVFNC8leHUN?si=n7FqhO6ZT02YVvMqPvZqFg"}
           ],
           "tags": ["Unknown Face", "Soul In Motion", "debut album", "deep DnB"]
         },
@@ -192,7 +192,7 @@
           "sources": [{"name": "UKF", "url": "https://ukf.com/listen/releases/the-rush/", "kind": "primary"}],
           "media": [
             {"type": "image", "url": "https://ukf.com/wp-content/uploads/2026/07/TSugah-TheRush-Artwork-v3-2.jpg"},
-            {"type": "spotify", "url": "https://open.spotify.com/track/78jhWm8GMFK5lxqWdXz0u5"}
+            {"type": "spotify", "url": "https://open.spotify.com/track/78jhWm8GMFK5lxqWdXz0u5?si=5421042b08c44def"}
           ],
           "tags": ["T & Sugah", "UKF", "dancefloor", "label move"]
         },


### PR DESCRIPTION
## Co se mění

- používá přesné Spotify URL dodané pro Unknown Face a T & Sugah
- vykresluje oba přehrávače pomocí úplného oficiálního Spotify iframe formátu
- odstraňuje doplňkový parametr motivu, který mohl v některých prohlížečích způsobovat prázdný panel
- přidává pod každý embed viditelné tlačítko `Otevřít ve Spotify` pro prohlížeče nebo rozšíření, která blokují third-party iframe

## Kontrola

- oba Spotify embedy se načítají na živém webu a obsahují správné album/track
- `python scripts/validate_briefing.py --all`: 29 reportů, 0 chyb, 0 varování
- JavaScript v `index.html`: syntakticky validní
- `git diff --check`: bez chyb