### PR TITLE
Fix DnB briefing 2026 week 33 recommended actions

### DIFF
--- a/news/2026-week_33.json
+++ b/news/2026-week_33.json
@@ -31,7 +31,7 @@
             "Značka tak pokračuje mimo evropský klubový a jednodenní model a buduje zimní DnB cestu do jihovýchodní Asie. Opakování akce je silnější důkaz životaschopnosti formátu než jednorázový vstup na nový trh."
           ],
           "why_it_matters": "Destination festival soutěží o stejný mezinárodní segment fanoušků a zimní cestovní rozpočet a současně vytváří další placený termín pro žádané DnB interprety.",
-          "recommended_action": "Porovnat lineupový překryv, základní cenu a délku pobytu Phuketu s mezinárodním prodejním argumentem Let It Rollu 2027.",
+          "recommended_action": "Bez akce, pouze informační přehled",
           "region": "global",
           "category": "competition",
           "competitors": ["DnB Allstars"],
@@ -56,7 +56,7 @@
             "Program staví na Pythiusovi, Monrroeovi, Klinicalovi, Emperorovi, Agressor Bunx a Merikanovi a doplňuje ho česká sestava. Jde o úzce vymezený neuro a deep produkt s přírodní lokací, instalacemi a nižší vstupní cenou než velké evropské campingové festivaly."
           ],
           "why_it_matters": "Darkshire oslovuje stejné české tvrdší DnB publikum dostupným třídenním produktem jen tři týdny po Let It Rollu a vytváří další domácí poptávku po stejných neuro jménech.",
-          "recommended_action": "Po akci porovnat veřejně viditelný prodej, lineupový překryv a reakce na venue, zvuk a zázemí s výsledky Let It Rollu 2026.",
+          "recommended_action": "Bez akce, pouze informační přehled",
           "region": "cz_sk",
           "category": "competition",
           "competitors": ["Darkshire"],
@@ -82,7 +82,7 @@
             "Organizátor uvedl, že 50 procent Británie je v podmínkách sucha a že může během dne řídit neesenciální spotřebu vody, aby zachoval klíčové zásoby. Komunikace spojila změny pravidel, zdravotní symptomy, požární riziko, vodu a prach do jednoho návštěvnického balíku."
           ],
           "why_it_matters": "Stejná kombinace vysokých teplot, suché půdy, omezeného stínu a velkého campingu může změnit zdravotní, požární i vodní plán venkovního LIR během několika hodin.",
-          "recommended_action": "Připravit předem schválenou heat and drought matici s prahy pro stín, zásobování vodou, prach, zákazy ohně a jednotnou krizovou komunikaci.",
+          "recommended_action": "Bez akce, pouze informační přehled",
           "region": "europe",
           "category": "competition",
           "competitors": ["Boomtown"],
@@ -113,7 +113,7 @@
             "Obě značky a jejich centrály v Mnichově a Hüttwilenu zůstávají zachované, skupinu vede dosavadní CEO NUSSLI Andy Böckli. Spojení rozšiřuje možnost nakoupit velkou část dočasné festivalové infrastruktury od jednoho dodavatele."
           ],
           "why_it_matters": "Konsolidace může zjednodušit koordinaci velkých staveb, ale současně zvyšuje závislost pořadatele na jednom dodavatelském celku a oslabuje oddělené cenové srovnání služeb.",
-          "recommended_action": "Zmapovat, zda jsou dodavatelé LIR 2027 napojeni na novou skupinu, a zachovat alternativní nabídky pro klíčové bariéry, povrchy a dočasné konstrukce.",
+          "recommended_action": "Bez akce, pouze informační přehled",
           "region": "europe",
           "category": "festival_industry",
           "competitors": [],
@@ -137,7 +137,7 @@
             "Cena nebyla oficiálně zveřejněna; Financial Times ji podle zdrojů odhadují na přibližně 4,5 miliardy liber. Transakce podléhá regulatornímu schválení a představuje největší dosavadní investici Mari do živé zábavy."
           ],
           "why_it_matters": "Další spojení venues, produkce, ticketingu a talentové sítě posiluje vertikálně integrované skupiny, které mohou ovlivňovat routing, dostupnost termínů, data o publiku i vyjednávací sílu nezávislých promotérů.",
-          "recommended_action": "Sledovat, zda ATG Live po schválení transakce rozšíří evropské festivalové nebo koncertní aktivity a zda se objeví dopad na routing agentury WME.",
+          "recommended_action": "Bez akce, pouze informační přehled",
           "region": "global",
           "category": "festival_industry",
           "competitors": [],
@@ -167,7 +167,7 @@
             "DJ Mag příběh zpracoval 10. srpna jako samostatnou zprávu a zveřejnil původní video. Formát spojil rychlou produkci, autentickou osobu z příběhu a koncertní vyvrcholení bez oddělených promo fází."
           ],
           "why_it_matters": "Ukazuje mimořádně rychlý obsahový cyklus, ve kterém nový zvuk, lidský příběh a živé vystoupení vzniknou současně a média mají hotový sdílitelný narativ.",
-          "recommended_action": "U vhodného momentu z cesty nebo backstage otestovat stejný jednodenní řetězec vznik zvuku, krátké video a živé použití bez inscenovaného příběhu.",
+          "recommended_action": "Bez akce, pouze informační přehled",
           "region": "global",
           "category": "dnb_scene",
           "competitors": [],
@@ -192,7 +192,7 @@
             "Před plošným vydáním bylo album od 31. července dva týdny dostupné pouze na Bandcampu v režimu pay what you want. Tento postup dal přímému prodeji, komunitě a vlastním datům časový náskok před algoritmickou distribucí."
           ],
           "why_it_matters": "Jde o praktický model, jak u fanouškovsky silného alba spojit přímý výnos a vztah s komunitou s následným dosahem streamovacích služeb bez trvalého omezení dostupnosti.",
-          "recommended_action": "Vybrat jeden vhodný delší release LIR Recordings a předem spočítat test sedmi až čtrnáctidenního Bandcamp first okna proti standardnímu současnému vydání.",
+          "recommended_action": "Bez akce, pouze informační přehled",
           "region": "global",
           "category": "dnb_scene",
           "competitors": [],


### PR DESCRIPTION
## Oprava

- nahrazuje všech sedm hodnot `recommended_action` předepsaným neutrálním textem `Bez akce, pouze informační přehled`
- nemění výběr zpráv, zdroje, manifest ani starší briefingy

## Důvod

Původní PR #21 byl mezitím sloučen, ale jeho doporučení odporují závazné specifikaci v `Zadání.txt` a `AUTOMATION.md`. Tato oprava vrací briefing do čistě informačního režimu.

## Kontrola

- změněn pouze `news/2026-week_33.json`
- všech 7 obsahových položek má přesnou předepsanou hodnotu
- JSON je syntakticky validní
