### PR TITLE
Rewrite DnB briefing 2026 week 33

### DIFF
--- a/news/2026-week_33.json
+++ b/news/2026-week_33.json
@@ -5,15 +5,15 @@
     "week": 33,
     "window_start": "2026-08-10",
     "window_end": "2026-08-16",
-    "generated_at": "2026-08-17T09:59:11+02:00"
+    "generated_at": "2026-08-17T11:07:39+02:00"
   },
-  "headline": "DnB Allstars rozšiřují destination model, Boomtown aktivoval režim pro vedro a dodavatelé eventové infrastruktury konsolidují",
+  "headline": "Boomtown vyvrcholil neohlášeným B2B Skrillexe s Chase & Status, Andromedik vydal Up a Justin Hawkes složil album pro souvislý poslech",
   "executive_summary": [
-    "DnB Allstars zveřejnili 15. srpna lineup návratového třídenního festivalu v Phuketu na 22. až 24. ledna 2027; vstupenky se prodávají od 129 liber.",
-    "Darkshire týden před Valley 2026 prodává třídenní lokální neuro festival za 1 990 Kč a staví program na Pythiusovi, Monrroeovi, Klinicalovi, Emperorovi a Agressor Bunx.",
-    "Boomtown při extrémním vedru a suchu nasadil zákaz otevřeného ohně a vařičů, vodní cisterny proti prachu, stíněné zóny a možnost omezit neesenciální spotřebu vody.",
-    "Spojení eps a NUSSLI vytvořilo skupinu s 820 zaměstnanci v 50 lokalitách, která spojuje ochranu povrchů, crowd control, tribuny, stages a dočasné stavby.",
-    "Justin Hawkes otestoval dvoutýdenní Bandcamp first distribuci s dobrovolnou cenou před vydáním dvanáctiskladbového alba na streamingu přes vlastní label."
+    "Skrillex v neděli uzavřel Boomtown neohlášeným B2B s Chase & Status a Flowdanem; DISTRX uvádí, že set na Hydro XL byl krátce přerušen kvůli tlaku davu.",
+    "Lion’s Den nabídl společný set Camo & Krooked, Mefjuse a Daxty i samostatné vystoupení Sub Focuse, které získalo výraznou odezvu v návštěvnických klipech.",
+    "Justin Hawkes vydal dvanáctiskladbové Now or Never jako nepřerušovaný albumový oblouk, jehož recenze i autor doporučují vnímat celou dramaturgii od začátku do konce.",
+    "Andromedik a Teddy Bee vydali singl Up, který se před zveřejněním objevoval v letních setech jako dosud nepojmenované ID.",
+    "Spojení eps a NUSSLI vytvořilo skupinu s 820 zaměstnanci v 50 lokalitách napříč crowd control, ochranou povrchů, tribunami, stages a dočasnými stavbami."
   ],
   "sections": [
     {
@@ -21,55 +21,138 @@
       "title": "Přímá konkurence",
       "items": [
         {
-          "id": "dnb-allstars-thailand-2027-lineup-return",
-          "published_at": "2026-08-15",
-          "event_start": "2027-01-22",
-          "event_end": "2027-01-24",
-          "title": "DnB Allstars mění Phuket z experimentu na opakovaný destination festival",
+          "id": "skrillex-chase-status-surprise-b2b-boomtown-2026",
+          "published_at": "2026-08-17",
+          "event_start": "2026-08-16",
+          "event_end": "2026-08-16",
+          "title": "Skrillex uzavřel Boomtown neohlášeným B2B s Chase & Status a Flowdanem",
           "summary": [
-            "DnB Allstars 15. srpna zveřejnili lineup druhého třídenního ročníku v Phuketu, který proběhne 22. až 24. ledna 2027. Megatix potvrzuje návrat značky po prvním ročníku 2026 a prodává vstupenky od 129 liber.",
-            "Značka tak pokračuje mimo evropský klubový a jednodenní model a buduje zimní DnB cestu do jihovýchodní Asie. Opakování akce je silnější důkaz životaschopnosti formátu než jednorázový vstup na nový trh."
+            "Skrillex v neděli 16. srpna zakončil Boomtown na stage Hydro XL a během setu přizval Chase & Status ke společnému B2B. Na pódiu se objevil také Flowdan.",
+            "DISTRX zveřejnil záznam v pondělí 17. srpna a v popisku uvádí, že Skrillex set krátce zastavil kvůli tlaku postupujícího davu. Další návštěvnický záznam potvrzuje společný závěr se Skrillexem a Chase & Status, ne však příčinu přerušení."
           ],
-          "why_it_matters": "Destination festival soutěží o stejný mezinárodní segment fanoušků a zimní cestovní rozpočet a současně vytváří další placený termín pro žádané DnB interprety.",
+          "why_it_matters": "Neohlášené spojení tří výrazných britských DnB a bass jmen vytvořilo jeden z nejsdílenějších momentů závěru festivalu; krátká pauza současně upozornila na crowd flow při překvapivém hostování.",
           "recommended_action": "Bez akce, pouze informační přehled",
-          "region": "global",
+          "region": "europe",
           "category": "competition",
-          "competitors": ["DnB Allstars"],
-          "confidence": "confirmed",
+          "competitors": [
+            "Boomtown"
+          ],
+          "confidence": "probable",
           "sources": [
-            {"name": "DnB Allstars — Instagram", "url": "https://www.instagram.com/dnballstars/reel/DcDuZIbo5RL/", "kind": "primary"},
-            {"name": "Megatix Thailand", "url": "https://megatix.in.th/DnBAllstars2027", "kind": "primary"}
+            {
+              "name": "DISTRX — Skrillex B2B Chase & Status",
+              "url": "https://www.instagram.com/p/DcImM-vE8I3/",
+              "kind": "secondary"
+            },
+            {
+              "name": "Návštěvnický záznam z Boomtownu",
+              "url": "https://www.instagram.com/reel/DcHzF_aCQB0/",
+              "kind": "secondary"
+            }
           ],
           "media": [
-            {"type": "instagram", "url": "https://www.instagram.com/dnballstars/reel/DcDuZIbo5RL/"}
+            {
+              "type": "instagram",
+              "url": "https://www.instagram.com/p/DcImM-vE8I3/"
+            }
           ],
-          "tags": ["DnB Allstars", "Thailand", "destination festival", "ticket price", "international expansion"]
+          "tags": [
+            "Boomtown",
+            "Skrillex",
+            "Chase & Status",
+            "Flowdan",
+            "surprise B2B",
+            "crowd flow"
+          ]
         },
         {
-          "id": "darkshire-valley-2026-final-week-positioning",
-          "published_at": "2026-08-14",
-          "event_start": "2026-08-21",
-          "event_end": "2026-08-23",
-          "title": "Darkshire Valley nabízí týden po hlavní sezoně třídenní neuro festival za 1 990 Kč",
+          "id": "camo-krooked-mefjus-daxta-boomtown-b2b-2026",
+          "published_at": "2026-08-15",
+          "event_start": "2026-08-15",
+          "event_end": "2026-08-15",
+          "title": "Camo & Krooked, Mefjus a Daxta přinesli do Lion’s Den společný B2B set",
           "summary": [
-            "Darkshire vstoupil 14. srpna do posledního týdne prodeje druhého ročníku In The Valley, který proběhne 21. až 23. srpna v Rájence u Zlína. GoOut uvádí cenu 1 990 Kč za třídenní akci.",
-            "Program staví na Pythiusovi, Monrroeovi, Klinicalovi, Emperorovi, Agressor Bunx a Merikanovi a doplňuje ho česká sestava. Jde o úzce vymezený neuro a deep produkt s přírodní lokací, instalacemi a nižší vstupní cenou než velké evropské campingové festivaly."
+            "Camo & Krooked a Mefjus odehráli na Boomtownu společný set na stage The Lion’s Den. Oficiální lineup jej uváděl jako Camo & Krooked B2B Mefjus ft. Daxta.",
+            "DISTRX zveřejnil 15. srpna několik klipů a označil vystoupení za jeden z výrazných setů víkendu. Jednorázové spojení dvou producentských projektů a MC tak dostalo samostatný programový prostor na jedné z největších venkovních stages festivalu."
           ],
-          "why_it_matters": "Darkshire oslovuje stejné české tvrdší DnB publikum dostupným třídenním produktem jen tři týdny po Let It Rollu a vytváří další domácí poptávku po stejných neuro jménech.",
+          "why_it_matters": "Společný set Camo & Krooked, Mefjuse a Daxty ukázal, jak Boomtown pracuje s exkluzivně působící kombinací známých jmen místo jejich odděleného zařazení do programu.",
           "recommended_action": "Bez akce, pouze informační přehled",
-          "region": "cz_sk",
+          "region": "europe",
           "category": "competition",
-          "competitors": ["Darkshire"],
+          "competitors": [
+            "Boomtown"
+          ],
           "confidence": "confirmed",
           "sources": [
-            {"name": "Darkshire — poslední týden", "url": "https://www.instagram.com/darkshire.events/p/DcBbth3CIE8/", "kind": "primary"},
-            {"name": "Darkshire", "url": "https://darkshire.cz/", "kind": "primary"},
-            {"name": "GoOut", "url": "https://goout.net/en/darkshire-festival-in-the-valley-2026/szgieiy/", "kind": "primary"}
+            {
+              "name": "DISTRX — Camo & Krooked B2B Mefjus",
+              "url": "https://www.instagram.com/p/DcE-E7Dk6m6/",
+              "kind": "secondary"
+            },
+            {
+              "name": "Boomtown — lineup 2026",
+              "url": "https://www.boomtownfair.co.uk/lineup",
+              "kind": "primary"
+            }
           ],
           "media": [
-            {"type": "instagram", "url": "https://www.instagram.com/darkshire.events/p/DcBbth3CIE8/"}
+            {
+              "type": "instagram",
+              "url": "https://www.instagram.com/p/DcE-E7Dk6m6/"
+            }
           ],
-          "tags": ["Darkshire", "neurofunk", "Czech Republic", "ticket price", "festival positioning"]
+          "tags": [
+            "Boomtown",
+            "Camo & Krooked",
+            "Mefjus",
+            "Daxta",
+            "B2B",
+            "Lion’s Den"
+          ]
+        },
+        {
+          "id": "sub-focus-lions-den-boomtown-response-2026",
+          "published_at": "2026-08-15",
+          "event_start": "2026-08-14",
+          "event_end": "2026-08-14",
+          "title": "Sub Focus získal na Boomtownu silnou odezvu za samostatný set v Lion’s Den",
+          "summary": [
+            "Sub Focus odehrál v pátek 14. srpna samostatný set na stage The Lion’s Den. Zveřejněný časový plán jej řadil do odpoledního slotu od 15:30 do 16:30.",
+            "DISTRX o den později publikoval sestřih a uvedl, že fanoušci set popisovali jako jeden z jeho nejlepších za delší dobu. Jde o reakci shrnutou jedním médiem, nikoli o měření celého publika, klipy však dokládají výrazný festivalový moment."
+          ],
+          "why_it_matters": "Odezva kolem odpoledního setu ukazuje, že Boomtown dokázal vytvořit široce sdílený headline moment i mimo noční program a bez speciálního B2B formátu.",
+          "recommended_action": "Bez akce, pouze informační přehled",
+          "region": "europe",
+          "category": "competition",
+          "competitors": [
+            "Boomtown"
+          ],
+          "confidence": "probable",
+          "sources": [
+            {
+              "name": "DISTRX — Sub Focus v Lion’s Den",
+              "url": "https://www.instagram.com/p/DcDUIXEk4ie/",
+              "kind": "secondary"
+            },
+            {
+              "name": "Time Out — Boomtown 2026 set times",
+              "url": "https://www.timeout.com/uk/news/boomtown-festival-2026-guide-set-times-lineup-tickets-081226",
+              "kind": "secondary"
+            }
+          ],
+          "media": [
+            {
+              "type": "instagram",
+              "url": "https://www.instagram.com/p/DcDUIXEk4ie/"
+            }
+          ],
+          "tags": [
+            "Boomtown",
+            "Sub Focus",
+            "Lion’s Den",
+            "festival set",
+            "audience response"
+          ]
         },
         {
           "id": "boomtown-extreme-heat-drought-response-2026",
@@ -85,16 +168,85 @@
           "recommended_action": "Bez akce, pouze informační přehled",
           "region": "europe",
           "category": "competition",
-          "competitors": ["Boomtown"],
+          "competitors": [
+            "Boomtown"
+          ],
           "confidence": "confirmed",
           "sources": [
-            {"name": "Boomtown — Arrivals Welfare Info", "url": "https://www.instagram.com/p/Db8GxWUALzq/", "kind": "primary"},
-            {"name": "Boomtown — Weather Information", "url": "https://www.boomtownfair.co.uk/info", "kind": "primary"}
+            {
+              "name": "Boomtown — Arrivals Welfare Info",
+              "url": "https://www.instagram.com/p/Db8GxWUALzq/",
+              "kind": "primary"
+            },
+            {
+              "name": "Boomtown — Weather Information",
+              "url": "https://www.boomtownfair.co.uk/info",
+              "kind": "primary"
+            }
           ],
           "media": [
-            {"type": "instagram", "url": "https://www.instagram.com/p/Db8GxWUALzq/"}
+            {
+              "type": "instagram",
+              "url": "https://www.instagram.com/p/Db8GxWUALzq/"
+            }
           ],
-          "tags": ["Boomtown", "extreme heat", "drought", "water", "fire safety", "dust"]
+          "tags": [
+            "Boomtown",
+            "extreme heat",
+            "drought",
+            "water",
+            "fire safety",
+            "dust"
+          ]
+        },
+        {
+          "id": "darkshire-valley-2026-final-week-positioning",
+          "published_at": "2026-08-14",
+          "event_start": "2026-08-21",
+          "event_end": "2026-08-23",
+          "title": "Darkshire Valley nabízí týden po hlavní sezoně třídenní neuro festival za 1 990 Kč",
+          "summary": [
+            "Darkshire vstoupil 14. srpna do posledního týdne prodeje druhého ročníku In The Valley, který proběhne 21. až 23. srpna v Rájence u Zlína. GoOut uvádí cenu 1 990 Kč za třídenní akci.",
+            "Program staví na Pythiusovi, Monrroeovi, Klinicalovi, Emperorovi, Agressor Bunx a Merikanovi a doplňuje ho česká sestava. Jde o úzce vymezený neuro a deep produkt s přírodní lokací, instalacemi a nižší vstupní cenou než velké evropské campingové festivaly."
+          ],
+          "why_it_matters": "Darkshire oslovuje stejné české tvrdší DnB publikum dostupným třídenním produktem jen tři týdny po Let It Rollu a vytváří další domácí poptávku po stejných neuro jménech.",
+          "recommended_action": "Bez akce, pouze informační přehled",
+          "region": "cz_sk",
+          "category": "competition",
+          "competitors": [
+            "Darkshire"
+          ],
+          "confidence": "confirmed",
+          "sources": [
+            {
+              "name": "Darkshire — poslední týden",
+              "url": "https://www.instagram.com/darkshire.events/p/DcBbth3CIE8/",
+              "kind": "primary"
+            },
+            {
+              "name": "Darkshire",
+              "url": "https://darkshire.cz/",
+              "kind": "primary"
+            },
+            {
+              "name": "GoOut",
+              "url": "https://goout.net/en/darkshire-festival-in-the-valley-2026/szgieiy/",
+              "kind": "primary"
+            }
+          ],
+          "media": [
+            {
+              "type": "instagram",
+              "url": "https://www.instagram.com/darkshire.events/p/DcBbth3CIE8/"
+            }
+          ],
+          "tags": [
+            "Darkshire",
+            "neurofunk",
+            "Czech Republic",
+            "ticket price",
+            "festival positioning"
+          ]
         }
       ]
     },
@@ -119,12 +271,30 @@
           "competitors": [],
           "confidence": "confirmed",
           "sources": [
-            {"name": "eps", "url": "https://eps.net/en/", "kind": "primary"},
-            {"name": "IQ Magazine", "url": "https://www.iqmagazine.com/2026/08/eps-and-nussli-merge-to-form-globally-active-event-infrastructure-group/", "kind": "secondary"},
-            {"name": "Access All Areas", "url": "https://accessaa.co.uk/eps-and-nussli-merge-to-create-new-group/", "kind": "secondary"}
+            {
+              "name": "eps",
+              "url": "https://eps.net/en/",
+              "kind": "primary"
+            },
+            {
+              "name": "IQ Magazine",
+              "url": "https://www.iqmagazine.com/2026/08/eps-and-nussli-merge-to-form-globally-active-event-infrastructure-group/",
+              "kind": "secondary"
+            },
+            {
+              "name": "Access All Areas",
+              "url": "https://accessaa.co.uk/eps-and-nussli-merge-to-create-new-group/",
+              "kind": "secondary"
+            }
           ],
           "media": [],
-          "tags": ["event infrastructure", "merger", "crowd control", "temporary structures", "suppliers"]
+          "tags": [
+            "event infrastructure",
+            "merger",
+            "crowd control",
+            "temporary structures",
+            "suppliers"
+          ]
         },
         {
           "id": "mari-acquires-atg-live-entertainment-2026",
@@ -143,12 +313,31 @@
           "competitors": [],
           "confidence": "confirmed",
           "sources": [
-            {"name": "IQ Magazine", "url": "https://www.iqmagazine.com/2026/08/atg-entertainment-acquired-by-ari-emanuels-mari-in-e5bn-deal/", "kind": "secondary"},
-            {"name": "Financial Times", "url": "https://www.ft.com/content/df4d2721-d84b-475a-8139-d58d7418a881", "kind": "secondary"},
-            {"name": "Variety", "url": "https://variety.com/2026/biz/global/ari-emanuel-mari-acquires-atg-entertainment-theater-venue-giant-1236832004/", "kind": "secondary"}
+            {
+              "name": "IQ Magazine",
+              "url": "https://www.iqmagazine.com/2026/08/atg-entertainment-acquired-by-ari-emanuels-mari-in-e5bn-deal/",
+              "kind": "secondary"
+            },
+            {
+              "name": "Financial Times",
+              "url": "https://www.ft.com/content/df4d2721-d84b-475a-8139-d58d7418a881",
+              "kind": "secondary"
+            },
+            {
+              "name": "Variety",
+              "url": "https://variety.com/2026/biz/global/ari-emanuel-mari-acquires-atg-entertainment-theater-venue-giant-1236832004/",
+              "kind": "secondary"
+            }
           ],
           "media": [],
-          "tags": ["M&A", "ATG Entertainment", "Mari", "venues", "ticketing", "vertical integration"]
+          "tags": [
+            "M&A",
+            "ATG Entertainment",
+            "Mari",
+            "venues",
+            "ticketing",
+            "vertical integration"
+          ]
         }
       ]
     },
@@ -173,39 +362,84 @@
           "competitors": [],
           "confidence": "confirmed",
           "sources": [
-            {"name": "Bou — Instagram", "url": "https://www.instagram.com/reel/DbvP0HlPXzo/", "kind": "primary"},
-            {"name": "DJ Mag", "url": "https://djmag.com/news/bou-brings-flight-attendant-stage-las-vegas-after-sampling-passenger-cabin-crew-confrontation", "kind": "secondary"}
+            {
+              "name": "Bou — Instagram",
+              "url": "https://www.instagram.com/reel/DbvP0HlPXzo/",
+              "kind": "primary"
+            },
+            {
+              "name": "DJ Mag",
+              "url": "https://djmag.com/news/bou-brings-flight-attendant-stage-las-vegas-after-sampling-passenger-cabin-crew-confrontation",
+              "kind": "secondary"
+            }
           ],
           "media": [
-            {"type": "instagram", "url": "https://www.instagram.com/reel/DbvP0HlPXzo/"}
+            {
+              "type": "instagram",
+              "url": "https://www.instagram.com/reel/DbvP0HlPXzo/"
+            }
           ],
-          "tags": ["Bou", "content format", "sampling", "live moment", "social media"]
+          "tags": [
+            "Bou",
+            "content format",
+            "sampling",
+            "live moment",
+            "social media"
+          ]
         },
         {
-          "id": "justin-hawkes-now-or-never-direct-first-release",
+          "id": "justin-hawkes-now-or-never-continuous-album-2026",
           "published_at": "2026-08-14",
           "event_start": null,
           "event_end": null,
-          "title": "Justin Hawkes dal vlastnímu labelu dvoutýdenní Bandcamp first okno před streamingem",
+          "title": "Justin Hawkes sestavil Now or Never jako album pro nepřerušovaný poslech",
           "summary": [
-            "Justin Hawkes vydal 14. srpna na DSP své druhé album Now Or Never: dvanáct skladeb napříč tech DnB, future jungle, halftime a jump upem. Album vyšlo přes jeho vlastní Drumcaste Collective a navazuje na katalog s více než 100 miliony streamů.",
-            "Před plošným vydáním bylo album od 31. července dva týdny dostupné pouze na Bandcampu v režimu pay what you want. Tento postup dal přímému prodeji, komunitě a vlastním datům časový náskok před algoritmickou distribucí."
+            "Justin Hawkes vydal 14. srpna na streamovacích službách své druhé album Now or Never přes vlastní Drumcaste Collective. Dvanáct skladeb je promícháno bez mezer a tvoří jeden souvislý oblouk místo kolekce volně seřazených singlů.",
+            "Recenze EDM Identity výslovně doporučuje poslech od začátku do konce a popisuje pohyb mezi tech DnB, future jungle, halftime a jump-upem. Kontrast mezi tvrdšími pasážemi, vokály, smyčci a klidnějšími přechody funguje jako dramaturgie celého alba, ne jen jednotlivých tracků.",
+            "V červnovém rozhovoru Hawkes popsal svůj cíl jako pestrou, postupně vystavěnou zkušenost od měkkých a osobních poloh po temné extrémy a upozornil, že při čistě davově orientovaném DJingu se tato jemnost často ztrácí."
           ],
-          "why_it_matters": "Jde o praktický model, jak u fanouškovsky silného alba spojit přímý výnos a vztah s komunitou s následným dosahem streamovacích služeb bez trvalého omezení dostupnosti.",
+          "why_it_matters": "Now or Never je po delší době materiál, u něhož pořadí skladeb není pouhý obal pro jednotlivé singly: souvislý mix, dynamika a návraty motivů jsou podstatnou částí výsledku.",
           "recommended_action": "Bez akce, pouze informační přehled",
           "region": "global",
           "category": "dnb_scene",
           "competitors": [],
           "confidence": "confirmed",
           "sources": [
-            {"name": "Justin Hawkes — Bandcamp", "url": "https://justinhawkes.bandcamp.com/album/now-or-never", "kind": "primary"},
-            {"name": "Data Transmission DnB", "url": "https://datatransmission.co/dt-dnb/justin-hawkes-releases-second-album-now-or-never/", "kind": "secondary"},
-            {"name": "Your EDM", "url": "https://www.youredm.com/2026/08/14/justin-hawkes-releases-second-album-now-or-never/", "kind": "secondary"}
+            {
+              "name": "Justin Hawkes — Bandcamp",
+              "url": "https://justinhawkes.bandcamp.com/album/now-or-never",
+              "kind": "primary"
+            },
+            {
+              "name": "EDM Identity — recenze Now or Never",
+              "url": "https://edmidentity.com/2026/08/15/justin-hawkes-now-or-never/",
+              "kind": "secondary"
+            },
+            {
+              "name": "EDM Identity — rozhovor s Justinem Hawkesem",
+              "url": "https://edmidentity.com/2026/06/12/drum-bass-devotions-022-justin-hawkes/",
+              "kind": "secondary"
+            },
+            {
+              "name": "Data Transmission DnB",
+              "url": "https://datatransmission.co/dt-dnb/justin-hawkes-releases-second-album-now-or-never/",
+              "kind": "secondary"
+            }
           ],
           "media": [
-            {"type": "instagram", "url": "https://www.instagram.com/p/DcB7iB0qj0l/"}
+            {
+              "type": "instagram",
+              "url": "https://www.instagram.com/p/DcB7iB0qj0l/"
+            }
           ],
-          "tags": ["Justin Hawkes", "Drumcaste Collective", "Bandcamp", "direct to fan", "release strategy"]
+          "tags": [
+            "Justin Hawkes",
+            "Now or Never",
+            "Drumcaste Collective",
+            "album",
+            "continuous mix",
+            "experiential DnB"
+          ]
         }
       ]
     },
@@ -222,7 +456,65 @@
     {
       "id": "strategic_releases",
       "title": "Strategické releasy",
-      "items": []
+      "items": [
+        {
+          "id": "andromedik-teddy-bee-up-single-2026",
+          "published_at": "2026-08-14",
+          "event_start": null,
+          "event_end": null,
+          "title": "Andromedik a Teddy Bee vydali nový singl Up",
+          "summary": [
+            "Andromedik vydal 14. srpna s Teddy Bee singl Up. Drum & Bass UK uvádí stopáž 3:23 a oficiální video potvrzuje licenci pro AEI Recordings.",
+            "Skladba se před vydáním objevovala v Andromedikových letních setech jako ID a DNB Direct ji takto zachytil krátce před zveřejněním. Výsledná verze spojuje jeho melodický festivalový DnB s plnohodnotnou vokální linkou Teddy Bee."
+          ],
+          "why_it_matters": "Up pokračuje v Andromedikově přechodu od krátkých festivalových ID k autorsky jasně označeným vokálním singlům a udržuje jeho melodický zvuk v hlavním evropském DnB proudu.",
+          "recommended_action": "Bez akce, pouze informační přehled",
+          "region": "europe",
+          "category": "strategic_release",
+          "competitors": [],
+          "confidence": "confirmed",
+          "sources": [
+            {
+              "name": "Andromedik — oznámení vydání",
+              "url": "https://www.instagram.com/p/DcBD3f8CPbc/",
+              "kind": "primary"
+            },
+            {
+              "name": "Andromedik — Up ft. Teddy Bee",
+              "url": "https://www.youtube.com/watch?v=rUfsAjxe7QY",
+              "kind": "primary"
+            },
+            {
+              "name": "DNB Direct — Andromedik ID",
+              "url": "https://www.instagram.com/dnbdirect/reel/DcDL2ZyoGDO/",
+              "kind": "secondary"
+            },
+            {
+              "name": "Drum & Bass UK",
+              "url": "https://drumandbassuk.com/artist/andromedik/up-2-64812",
+              "kind": "secondary"
+            }
+          ],
+          "media": [
+            {
+              "type": "instagram",
+              "url": "https://www.instagram.com/dnbdirect/reel/DcDL2ZyoGDO/"
+            },
+            {
+              "type": "youtube",
+              "url": "https://www.youtube.com/watch?v=rUfsAjxe7QY"
+            }
+          ],
+          "tags": [
+            "Andromedik",
+            "Teddy Bee",
+            "Up",
+            "single",
+            "melodic DnB",
+            "AEI Recordings"
+          ]
+        }
+      ]
     },
     {
       "id": "lir_actions",
@@ -259,6 +551,11 @@
     "Reddit r/BoomtownFestival",
     "DnB Allstars",
     "Darkshire",
-    "Boomtown"
+    "Boomtown",
+    "DISTRX",
+    "EDM Identity",
+    "Justin Hawkes — Bandcamp",
+    "Andromedik",
+    "DNB Direct"
   ]
 }


### PR DESCRIPTION
## Přepracování briefingu

- otevírá briefing třemi konkrétními momenty z Boomtownu: Skrillex B2B Chase & Status s Flowdanem, Camo & Krooked B2B Mefjus ft. Daxta a Sub Focus v Lion’s Den
- zachovává pravdivé datum pondělního příspěvku o nedělním závěru Boomtownu a odděluje doložený průběh od tvrzení DISTRX o crowd surge
- přidává singl Andromedik & Teddy Bee — Up včetně oficiálního releasu a předchozího ID
- přepisuje položku o Justinovi Hawkesovi jako rozbor souvislé dramaturgie alba Now or Never, opřený o Bandcamp, recenzi EDM Identity, rozhovor a Data Transmission
- vypouští vzdálený lednový festival DnB Allstars a ponechává deset nejsilnějších položek

## Kontrola

- změněn pouze `news/2026-week_33.json`
- 10 obsahových položek, z toho 2 v `dnb_scene`
- všech 10 hodnot `recommended_action` odpovídá závaznému neutrálnímu textu
- zachováno pořadí sedmi sekcí, povinný Reddit sweep a prázdná sekce `lir_actions`
- bez duplicitních ID a zdrojových URL
