### PR TITLE
Finalize DnB briefing 2026 week 33

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,12 +94,12 @@
   <script>
     const state = { manifest: [] };
     const displayOrder = [
+      "competition",
+      "festival_industry",
       "dnb_scene",
-      "strategic_releases",
       "cz_sk",
       "audience_sentiment",
-      "competition",
-      "festival_industry"
+      "strategic_releases"
     ];
     const categoryNames = {
       competition: "Přímá konkurence",

--- a/news/2026-week_33.json
+++ b/news/2026-week_33.json
@@ -7,13 +7,12 @@
     "window_end": "2026-08-16",
     "generated_at": "2026-08-17T11:07:39+02:00"
   },
-  "headline": "Boomtown vyvrcholil neohlášeným B2B Skrillexe s Chase & Status, Andromedik vydal Up a Justin Hawkes složil album pro souvislý poslech",
+  "headline": "Boomtown vyvrcholil překvapivým B2B Skrillexe s Chase & Status, Andromedik vydal Up a Justin Hawkes složil album pro souvislý poslech",
   "executive_summary": [
-    "Skrillex v neděli uzavřel Boomtown neohlášeným B2B s Chase & Status a Flowdanem; DISTRX uvádí, že set na Hydro XL byl krátce přerušen kvůli tlaku davu.",
+    "Skrillex v neděli uzavřel Boomtown překvapivým B2B s Chase & Status a Flowdanem; DISTRX uvádí, že set na Hydro XL byl krátce přerušen kvůli tlaku davu.",
     "Lion’s Den nabídl společný set Camo & Krooked, Mefjuse a Daxty i samostatné vystoupení Sub Focuse, které získalo výraznou odezvu v návštěvnických klipech.",
-    "Justin Hawkes vydal dvanáctiskladbové Now or Never jako nepřerušovaný albumový oblouk, jehož recenze i autor doporučují vnímat celou dramaturgii od začátku do konce.",
-    "Andromedik a Teddy Bee vydali singl Up, který se před zveřejněním objevoval v letních setech jako dosud nepojmenované ID.",
-    "Spojení eps a NUSSLI vytvořilo skupinu s 820 zaměstnanci v 50 lokalitách napříč crowd control, ochranou povrchů, tribunami, stages a dočasnými stavbami."
+    "Justin Hawkes vydal dvanáctiskladbové Now or Never jako nepřerušovaný albumový oblouk postavený pro poslech od začátku do konce.",
+    "Andromedik a Teddy Bee vydali singl Up, který Andromedik před vydáním testoval na Tomorrowlandu jako dosud nevydané ID."
   ],
   "sections": [
     {
@@ -25,12 +24,12 @@
           "published_at": "2026-08-17",
           "event_start": "2026-08-16",
           "event_end": "2026-08-16",
-          "title": "Skrillex uzavřel Boomtown neohlášeným B2B s Chase & Status a Flowdanem",
+          "title": "Skrillex uzavřel Boomtown překvapivým B2B s Chase & Status a Flowdanem",
           "summary": [
             "Skrillex v neděli 16. srpna zakončil Boomtown na stage Hydro XL a během setu přizval Chase & Status ke společnému B2B. Na pódiu se objevil také Flowdan.",
             "DISTRX zveřejnil záznam v pondělí 17. srpna a v popisku uvádí, že Skrillex set krátce zastavil kvůli tlaku postupujícího davu. Další návštěvnický záznam potvrzuje společný závěr se Skrillexem a Chase & Status, ne však příčinu přerušení."
           ],
-          "why_it_matters": "Neohlášené spojení tří výrazných britských DnB a bass jmen vytvořilo jeden z nejsdílenějších momentů závěru festivalu; krátká pauza současně upozornila na crowd flow při překvapivém hostování.",
+          "why_it_matters": "Překvapivé spojení Skrillexe, Chase & Status a Flowdana vytvořilo jeden z nejsilnějších momentů závěru festivalu. Krátké přerušení současně ukázalo tlak, který může neohlášené hostování vyvolat na pohyb publika.",
           "recommended_action": "Bez akce, pouze informační přehled",
           "region": "europe",
           "category": "competition",
@@ -70,12 +69,12 @@
           "published_at": "2026-08-15",
           "event_start": "2026-08-15",
           "event_end": "2026-08-15",
-          "title": "Camo & Krooked, Mefjus a Daxta přinesli do Lion’s Den společný B2B set",
+          "title": "Camo & Krooked, Mefjus a Daxta spojili síly na Lion’s Den",
           "summary": [
             "Camo & Krooked a Mefjus odehráli na Boomtownu společný set na stage The Lion’s Den. Oficiální lineup jej uváděl jako Camo & Krooked B2B Mefjus ft. Daxta.",
-            "DISTRX zveřejnil 15. srpna několik klipů a označil vystoupení za jeden z výrazných setů víkendu. Jednorázové spojení dvou producentských projektů a MC tak dostalo samostatný programový prostor na jedné z největších venkovních stages festivalu."
+            "DISTRX zveřejnil 15. srpna několik klipů a zařadil vystoupení mezi výrazné sety víkendu. Boomtown tak místo tří oddělených jmen postavil jeden společný festivalový set dvou producentských projektů a MC."
           ],
-          "why_it_matters": "Společný set Camo & Krooked, Mefjuse a Daxty ukázal, jak Boomtown pracuje s exkluzivně působící kombinací známých jmen místo jejich odděleného zařazení do programu.",
+          "why_it_matters": "Společný set ukázal, jak Boomtown vytváří jedinečný programový moment kombinací interpretů, kteří by samostatně patřili k výrazným jménům lineupu.",
           "recommended_action": "Bez akce, pouze informační přehled",
           "region": "europe",
           "category": "competition",
@@ -115,12 +114,12 @@
           "published_at": "2026-08-15",
           "event_start": "2026-08-14",
           "event_end": "2026-08-14",
-          "title": "Sub Focus získal na Boomtownu silnou odezvu za samostatný set v Lion’s Den",
+          "title": "Sub Focus patřil k nejvýraznějším setům na Lion’s Den",
           "summary": [
             "Sub Focus odehrál v pátek 14. srpna samostatný set na stage The Lion’s Den. Zveřejněný časový plán jej řadil do odpoledního slotu od 15:30 do 16:30.",
-            "DISTRX o den později publikoval sestřih a uvedl, že fanoušci set popisovali jako jeden z jeho nejlepších za delší dobu. Jde o reakci shrnutou jedním médiem, nikoli o měření celého publika, klipy však dokládají výrazný festivalový moment."
+            "DISTRX o den později publikoval sestřih a uvedl, že fanoušci set popisovali jako jeden z jeho nejlepších za delší dobu. Hodnocení vychází z reakcí zachycených tímto médiem, klipy ale dokládají silnou odezvu publika během vystoupení."
           ],
-          "why_it_matters": "Odezva kolem odpoledního setu ukazuje, že Boomtown dokázal vytvořit široce sdílený headline moment i mimo noční program a bez speciálního B2B formátu.",
+          "why_it_matters": "Boomtown vytvořil výrazně sdílený moment i z běžného odpoledního slotu, bez překvapivých hostů nebo speciálního B2B formátu.",
           "recommended_action": "Bez akce, pouze informační přehled",
           "region": "europe",
           "category": "competition",
@@ -204,10 +203,10 @@
           "published_at": "2026-08-14",
           "event_start": "2026-08-21",
           "event_end": "2026-08-23",
-          "title": "Darkshire Valley nabízí týden po hlavní sezoně třídenní neuro festival za 1 990 Kč",
+          "title": "Darkshire Valley vstoupil do posledního týdne s třídenní vstupenkou za 1 990 Kč",
           "summary": [
-            "Darkshire vstoupil 14. srpna do posledního týdne prodeje druhého ročníku In The Valley, který proběhne 21. až 23. srpna v Rájence u Zlína. GoOut uvádí cenu 1 990 Kč za třídenní akci.",
-            "Program staví na Pythiusovi, Monrroeovi, Klinicalovi, Emperorovi, Agressor Bunx a Merikanovi a doplňuje ho česká sestava. Jde o úzce vymezený neuro a deep produkt s přírodní lokací, instalacemi a nižší vstupní cenou než velké evropské campingové festivaly."
+            "Darkshire vstoupil 14. srpna do posledního týdne prodeje druhého ročníku In The Valley, který proběhne 21. až 23. srpna v Rájence u Pohořelic poblíž Zlína. GoOut uvádí cenu 1 990 Kč za třídenní akci.",
+            "Program staví na Pythiusovi, Monrroeovi, Klinicalovi, Emperorovi, Agressor Bunx a Merikanovi a doplňuje ho česká sestava. Festival nabízí úzce zaměřený neuro a deep program v přírodní lokalitě s nižší vstupní cenou než velké evropské campingové festivaly."
           ],
           "why_it_matters": "Darkshire oslovuje stejné české tvrdší DnB publikum dostupným třídenním produktem jen tři týdny po Let It Rollu a vytváří další domácí poptávku po stejných neuro jménech.",
           "recommended_action": "Bez akce, pouze informační přehled",
@@ -224,8 +223,8 @@
               "kind": "primary"
             },
             {
-              "name": "Darkshire",
-              "url": "https://darkshire.cz/",
+              "name": "Darkshire — kompletní lineup",
+              "url": "https://darkshire.cz/line-up/",
               "kind": "primary"
             },
             {
@@ -235,6 +234,10 @@
             }
           ],
           "media": [
+            {
+              "type": "image",
+              "url": "https://darkshire.cz/wp-content/uploads/2026/05/full-lineup-4_5-jpg.jpg"
+            },
             {
               "type": "instagram",
               "url": "https://www.instagram.com/darkshire.events/p/DcBbth3CIE8/"
@@ -253,98 +256,119 @@
     {
       "id": "festival_industry",
       "title": "Festivalový průmysl",
-      "items": [
-        {
-          "id": "eps-nussli-event-infrastructure-merger-2026",
-          "published_at": "2026-08-12",
-          "event_start": null,
-          "event_end": null,
-          "title": "eps a NUSSLI spojily crowd control, ochranu povrchů a dočasné stavby do jedné skupiny",
-          "summary": [
-            "Dodavatelé eps a NUSSLI oznámili spojení do evropské skupiny s globální působností. Nový celek má 820 zaměstnanců v 50 lokalitách a nabízí ochranu povrchů, crowd control, tribuny, stages, speciální konstrukce a dočasné stadiony.",
-            "Obě značky a jejich centrály v Mnichově a Hüttwilenu zůstávají zachované, skupinu vede dosavadní CEO NUSSLI Andy Böckli. Spojení rozšiřuje možnost nakoupit velkou část dočasné festivalové infrastruktury od jednoho dodavatele."
-          ],
-          "why_it_matters": "Konsolidace může zjednodušit koordinaci velkých staveb, ale současně zvyšuje závislost pořadatele na jednom dodavatelském celku a oslabuje oddělené cenové srovnání služeb.",
-          "recommended_action": "Bez akce, pouze informační přehled",
-          "region": "europe",
-          "category": "festival_industry",
-          "competitors": [],
-          "confidence": "confirmed",
-          "sources": [
-            {
-              "name": "eps",
-              "url": "https://eps.net/en/",
-              "kind": "primary"
-            },
-            {
-              "name": "IQ Magazine",
-              "url": "https://www.iqmagazine.com/2026/08/eps-and-nussli-merge-to-form-globally-active-event-infrastructure-group/",
-              "kind": "secondary"
-            },
-            {
-              "name": "Access All Areas",
-              "url": "https://accessaa.co.uk/eps-and-nussli-merge-to-create-new-group/",
-              "kind": "secondary"
-            }
-          ],
-          "media": [],
-          "tags": [
-            "event infrastructure",
-            "merger",
-            "crowd control",
-            "temporary structures",
-            "suppliers"
-          ]
-        },
-        {
-          "id": "mari-acquires-atg-live-entertainment-2026",
-          "published_at": "2026-08-11",
-          "event_start": null,
-          "event_end": null,
-          "title": "Mari kupuje ATG a propojuje 70 venues, produkci a ticketing v obchodu za přibližně 4,5 miliardy liber",
-          "summary": [
-            "Skupina Mari Ariho Emanuela se dohodla na převzetí ATG Entertainment od Providence Equity. ATG provozuje 70 venues v Británii, USA, Německu a Španělsku a vedle správy prostor vlastní produkční a ticketingové kapacity.",
-            "Cena nebyla oficiálně zveřejněna; Financial Times ji podle zdrojů odhadují na přibližně 4,5 miliardy liber. Transakce podléhá regulatornímu schválení a představuje největší dosavadní investici Mari do živé zábavy."
-          ],
-          "why_it_matters": "Další spojení venues, produkce, ticketingu a talentové sítě posiluje vertikálně integrované skupiny, které mohou ovlivňovat routing, dostupnost termínů, data o publiku i vyjednávací sílu nezávislých promotérů.",
-          "recommended_action": "Bez akce, pouze informační přehled",
-          "region": "global",
-          "category": "festival_industry",
-          "competitors": [],
-          "confidence": "confirmed",
-          "sources": [
-            {
-              "name": "IQ Magazine",
-              "url": "https://www.iqmagazine.com/2026/08/atg-entertainment-acquired-by-ari-emanuels-mari-in-e5bn-deal/",
-              "kind": "secondary"
-            },
-            {
-              "name": "Financial Times",
-              "url": "https://www.ft.com/content/df4d2721-d84b-475a-8139-d58d7418a881",
-              "kind": "secondary"
-            },
-            {
-              "name": "Variety",
-              "url": "https://variety.com/2026/biz/global/ari-emanuel-mari-acquires-atg-entertainment-theater-venue-giant-1236832004/",
-              "kind": "secondary"
-            }
-          ],
-          "media": [],
-          "tags": [
-            "M&A",
-            "ATG Entertainment",
-            "Mari",
-            "venues",
-            "ticketing",
-            "vertical integration"
-          ]
-        }
-      ]
+      "items": []
     },
     {
       "id": "dnb_scene",
       "title": "DnB scéna",
       "items": [
+        {
+          "id": "justin-hawkes-now-or-never-continuous-album-2026",
+          "published_at": "2026-08-14",
+          "event_start": null,
+          "event_end": null,
+          "title": "Justin Hawkes postavil Now or Never jako album pro poslech od začátku do konce",
+          "summary": [
+            "Justin Hawkes vydal 14. srpna na streamovacích službách své druhé album Now or Never přes vlastní Drumcaste Collective. Dvanáct skladeb je promícháno bez mezer a tvoří jeden souvislý oblouk místo kolekce volně seřazených singlů.",
+            "Recenze EDM Identity výslovně doporučuje poslech od začátku do konce a popisuje pohyb mezi tech DnB, future jungle, halftime a jump-upem. Kontrast mezi tvrdšími pasážemi, vokály, smyčci a klidnějšími přechody funguje jako dramaturgie celého alba, ne pouze jednotlivých tracků.",
+            "V červnovém rozhovoru Hawkes popsal svůj cíl jako pestrou, postupně vystavěnou zkušenost od měkkých a osobních poloh po temné extrémy a upozornil, že při čistě davově orientovaném DJingu se podobná jemnost často ztrácí."
+          ],
+          "why_it_matters": "Now or Never je po delší době DnB album, u něhož pořadí skladeb není pouhým obalem pro jednotlivé singly. Souvislý mix, vývoj energie a návraty motivů tvoří podstatnou část výsledku.",
+          "recommended_action": "Bez akce, pouze informační přehled",
+          "region": "global",
+          "category": "dnb_scene",
+          "competitors": [],
+          "confidence": "confirmed",
+          "sources": [
+            {
+              "name": "Justin Hawkes — Bandcamp",
+              "url": "https://justinhawkes.bandcamp.com/album/now-or-never",
+              "kind": "primary"
+            },
+            {
+              "name": "EDM Identity — recenze Now or Never",
+              "url": "https://edmidentity.com/2026/08/15/justin-hawkes-now-or-never/",
+              "kind": "secondary"
+            },
+            {
+              "name": "EDM Identity — rozhovor s Justinem Hawkesem",
+              "url": "https://edmidentity.com/2026/06/12/drum-bass-devotions-022-justin-hawkes/",
+              "kind": "secondary"
+            },
+            {
+              "name": "Data Transmission DnB",
+              "url": "https://datatransmission.co/dt-dnb/justin-hawkes-releases-second-album-now-or-never/",
+              "kind": "secondary"
+            }
+          ],
+          "media": [
+            {
+              "type": "spotify",
+              "url": "https://open.spotify.com/album/3Iaqa0EGfOgqiJ00zhJKOC"
+            }
+          ],
+          "tags": [
+            "Justin Hawkes",
+            "Now or Never",
+            "Drumcaste Collective",
+            "album",
+            "continuous mix",
+            "experiential DnB"
+          ]
+        },
+        {
+          "id": "andromedik-teddy-bee-up-single-2026",
+          "published_at": "2026-08-14",
+          "event_start": null,
+          "event_end": null,
+          "title": "Andromedik vydal s Teddy Bee nový singl Up",
+          "summary": [
+            "Andromedik vydal 14. srpna s Teddy Bee singl Up. Drum & Bass UK uvádí stopáž 3:23 a oficiální video potvrzuje licenci pro AEI Recordings.",
+            "Skladba se před vydáním objevovala v jeho letních setech jako ID. DNB Direct zveřejnil záběr, na kterém ji Andromedik hraje na Tomorrowlandu, ještě před zveřejněním finální verze."
+          ],
+          "why_it_matters": "Up převádí další výrazné festivalové ID do plnohodnotného vokálního singlu a pokračuje v Andromedikově melodické linii určené pro velká evropská pódia.",
+          "recommended_action": "Bez akce, pouze informační přehled",
+          "region": "europe",
+          "category": "dnb_scene",
+          "competitors": [],
+          "confidence": "confirmed",
+          "sources": [
+            {
+              "name": "Andromedik — oznámení vydání",
+              "url": "https://www.instagram.com/p/DcBD3f8CPbc/",
+              "kind": "primary"
+            },
+            {
+              "name": "Andromedik — Up ft. Teddy Bee",
+              "url": "https://www.youtube.com/watch?v=rUfsAjxe7QY",
+              "kind": "primary"
+            },
+            {
+              "name": "DNB Direct — Andromedik hraje Up na Tomorrowlandu",
+              "url": "https://www.instagram.com/dnbdirect/reel/DcDL2ZyoGDO/",
+              "kind": "secondary"
+            },
+            {
+              "name": "Drum & Bass UK",
+              "url": "https://drumandbassuk.com/artist/andromedik/up-2-64812",
+              "kind": "secondary"
+            }
+          ],
+          "media": [
+            {
+              "type": "instagram",
+              "url": "https://www.instagram.com/p/DcDL2ZyoGDO/"
+            }
+          ],
+          "tags": [
+            "Andromedik",
+            "Teddy Bee",
+            "Up",
+            "single",
+            "melodic DnB",
+            "AEI Recordings"
+          ]
+        },
         {
           "id": "bou-real-time-sample-las-vegas-content-loop",
           "published_at": "2026-08-10",
@@ -386,60 +410,6 @@
             "live moment",
             "social media"
           ]
-        },
-        {
-          "id": "justin-hawkes-now-or-never-continuous-album-2026",
-          "published_at": "2026-08-14",
-          "event_start": null,
-          "event_end": null,
-          "title": "Justin Hawkes sestavil Now or Never jako album pro nepřerušovaný poslech",
-          "summary": [
-            "Justin Hawkes vydal 14. srpna na streamovacích službách své druhé album Now or Never přes vlastní Drumcaste Collective. Dvanáct skladeb je promícháno bez mezer a tvoří jeden souvislý oblouk místo kolekce volně seřazených singlů.",
-            "Recenze EDM Identity výslovně doporučuje poslech od začátku do konce a popisuje pohyb mezi tech DnB, future jungle, halftime a jump-upem. Kontrast mezi tvrdšími pasážemi, vokály, smyčci a klidnějšími přechody funguje jako dramaturgie celého alba, ne jen jednotlivých tracků.",
-            "V červnovém rozhovoru Hawkes popsal svůj cíl jako pestrou, postupně vystavěnou zkušenost od měkkých a osobních poloh po temné extrémy a upozornil, že při čistě davově orientovaném DJingu se tato jemnost často ztrácí."
-          ],
-          "why_it_matters": "Now or Never je po delší době materiál, u něhož pořadí skladeb není pouhý obal pro jednotlivé singly: souvislý mix, dynamika a návraty motivů jsou podstatnou částí výsledku.",
-          "recommended_action": "Bez akce, pouze informační přehled",
-          "region": "global",
-          "category": "dnb_scene",
-          "competitors": [],
-          "confidence": "confirmed",
-          "sources": [
-            {
-              "name": "Justin Hawkes — Bandcamp",
-              "url": "https://justinhawkes.bandcamp.com/album/now-or-never",
-              "kind": "primary"
-            },
-            {
-              "name": "EDM Identity — recenze Now or Never",
-              "url": "https://edmidentity.com/2026/08/15/justin-hawkes-now-or-never/",
-              "kind": "secondary"
-            },
-            {
-              "name": "EDM Identity — rozhovor s Justinem Hawkesem",
-              "url": "https://edmidentity.com/2026/06/12/drum-bass-devotions-022-justin-hawkes/",
-              "kind": "secondary"
-            },
-            {
-              "name": "Data Transmission DnB",
-              "url": "https://datatransmission.co/dt-dnb/justin-hawkes-releases-second-album-now-or-never/",
-              "kind": "secondary"
-            }
-          ],
-          "media": [
-            {
-              "type": "instagram",
-              "url": "https://www.instagram.com/p/DcB7iB0qj0l/"
-            }
-          ],
-          "tags": [
-            "Justin Hawkes",
-            "Now or Never",
-            "Drumcaste Collective",
-            "album",
-            "continuous mix",
-            "experiential DnB"
-          ]
         }
       ]
     },
@@ -456,65 +426,7 @@
     {
       "id": "strategic_releases",
       "title": "Strategické releasy",
-      "items": [
-        {
-          "id": "andromedik-teddy-bee-up-single-2026",
-          "published_at": "2026-08-14",
-          "event_start": null,
-          "event_end": null,
-          "title": "Andromedik a Teddy Bee vydali nový singl Up",
-          "summary": [
-            "Andromedik vydal 14. srpna s Teddy Bee singl Up. Drum & Bass UK uvádí stopáž 3:23 a oficiální video potvrzuje licenci pro AEI Recordings.",
-            "Skladba se před vydáním objevovala v Andromedikových letních setech jako ID a DNB Direct ji takto zachytil krátce před zveřejněním. Výsledná verze spojuje jeho melodický festivalový DnB s plnohodnotnou vokální linkou Teddy Bee."
-          ],
-          "why_it_matters": "Up pokračuje v Andromedikově přechodu od krátkých festivalových ID k autorsky jasně označeným vokálním singlům a udržuje jeho melodický zvuk v hlavním evropském DnB proudu.",
-          "recommended_action": "Bez akce, pouze informační přehled",
-          "region": "europe",
-          "category": "strategic_release",
-          "competitors": [],
-          "confidence": "confirmed",
-          "sources": [
-            {
-              "name": "Andromedik — oznámení vydání",
-              "url": "https://www.instagram.com/p/DcBD3f8CPbc/",
-              "kind": "primary"
-            },
-            {
-              "name": "Andromedik — Up ft. Teddy Bee",
-              "url": "https://www.youtube.com/watch?v=rUfsAjxe7QY",
-              "kind": "primary"
-            },
-            {
-              "name": "DNB Direct — Andromedik ID",
-              "url": "https://www.instagram.com/dnbdirect/reel/DcDL2ZyoGDO/",
-              "kind": "secondary"
-            },
-            {
-              "name": "Drum & Bass UK",
-              "url": "https://drumandbassuk.com/artist/andromedik/up-2-64812",
-              "kind": "secondary"
-            }
-          ],
-          "media": [
-            {
-              "type": "instagram",
-              "url": "https://www.instagram.com/dnbdirect/reel/DcDL2ZyoGDO/"
-            },
-            {
-              "type": "youtube",
-              "url": "https://www.youtube.com/watch?v=rUfsAjxe7QY"
-            }
-          ],
-          "tags": [
-            "Andromedik",
-            "Teddy Bee",
-            "Up",
-            "single",
-            "melodic DnB",
-            "AEI Recordings"
-          ]
-        }
-      ]
+      "items": []
     },
     {
       "id": "lir_actions",


### PR DESCRIPTION
## Finální úprava týdne 33

- řadí konkurenční zprávy před scénové položky, takže briefing otevírá Skrillex s Chase & Status
- ponechává všechny zprávy z Boomtownu bezprostředně za sebou
- přesouvá Bou na úplný konec obsahového přehledu
- přidává Spotify přehrávač k albu Justina Hawkese
- používá Instagram z Tomorrowlandu u Andromedika
- přidává oficiální lineupový plakát Darkshire Valley
- odstraňuje položky eps a NUSSLI a Mari s ATG

## Kontrola

- 8 obsahových položek
- 3 položky v `dnb_scene`
- validace celého archivu: 0 chyb
- lokální pomocné soubory náhledu nejsou součástí změny
